### PR TITLE
adding idea suggested in #330

### DIFF
--- a/src/eval/module.jl
+++ b/src/eval/module.jl
@@ -36,7 +36,7 @@ function newmodule(name::String)::Module
         redirect_stderr(outf) do
             mod = Core.eval(Main, Meta.parse("""
                 module $name
-                    import Franklin: @OUTPUT, fdplotly
+                    import Franklin: @OUTPUT, fdplotly, locvar
                 end
                 """))
         end

--- a/test/eval/integration.jl
+++ b/test/eval/integration.jl
@@ -1,0 +1,15 @@
+# see also https://github.com/tlienart/Franklin.jl/issues/330
+@testset "locvar" begin
+    s = raw"""
+        @def va = 5
+        @def vb = 7
+        ```julia:ex
+        #hideall
+        println(locvar("va")+locvar("vb"))
+        ```
+        \output{ex}
+        """ |> fd2html_td
+    @test isapproxstr(s, """
+         <pre><code class="plaintext">12</code></pre>
+        """)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,7 @@ include("eval/run.jl")
 include("eval/io.jl")
 include("eval/codeblock.jl")
 include("eval/eval.jl")
+include("eval/integration.jl")
 
 # CONVERTER folder
 println("CONVERTER/MD")


### PR DESCRIPTION
It seemed like a nice idea to have access to the local page vars in code blocks.

This PR makes it possible to use the `locvar` function which takes a string indicating the variable name. So this for instance:

`````markdown
@def va = 5
@def vb = 7
```julia:ex
#hideall
println(locvar("va")+locvar("vb"))
```
\output{ex}
`````

will output

```html
<pre><code class="plaintext">12</code></pre>
```