### PR TITLE
Bug fixes + ignore features

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.6.4"
+version = "0.6.5"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/converter/latex/io.jl
+++ b/src/converter/latex/io.jl
@@ -142,6 +142,7 @@ function lx_figalt(lxc::LxCom, _)
     alt   = strip(content(lxc.braces[1]))
     path  = parse_rpath(rpath; canonical=false, code=true)
     fdir, fext = splitext(path)
+    
     # there are several cases
     # A. a path with no extension --> guess extension
     # B. a path with extension --> use that
@@ -173,7 +174,7 @@ function lx_figalt(lxc::LxCom, _)
             isfile(syspath) && return html_img(candpath, alt)
         end
     end
-    return html_err("Image matching '$rpath' not found.")
+    return html_err("Image matching '$path' not found.")
 end
 
 """

--- a/src/converter/markdown/blocks.jl
+++ b/src/converter/markdown/blocks.jl
@@ -165,7 +165,7 @@ function convert_footnote_ref(β::Token)::String
         push!(PAGE_FNREFS, id)
         pos = length(PAGE_FNREFS)
     end
-    return html_sup("fnref:$id", html_ahref(url_curpage() * "#fndef:$id", "[$pos]"; class="fnref"))
+    return html_sup("fnref:$id", html_ahref("#fndef:$id", "[$pos]"; class="fnref"))
 end
 
 """
@@ -193,7 +193,7 @@ function convert_footnote_def(β::OCBlock, lxdefs::Vector{LxDef})::String
     """
     <table class="fndef" id="fndef:$id">
         <tr>
-            <td class=\"fndef-backref\">$(html_ahref(url_curpage() * "#fnref:$id", "[$pos]"))</td>
+            <td class=\"fndef-backref\">$(html_ahref("#fnref:$id", "[$pos]"))</td>
             <td class=\"fndef-content\">$(ct)</td>
         </tr>
     </table>

--- a/src/eval/io.jl
+++ b/src/eval/io.jl
@@ -95,16 +95,22 @@ function parse_rpath(rpath::AS; canonical::Bool=false, code::Bool=false)::AS
             throw(RelativePathError("Relative path `$rpath` doesn't " *
                                     "look right."))
         end
+        # if the locvar ends with `index.md` but is not strictly
+        # index.md then remove it
+        loc_rpath = locvar("fd_rpath")
+        if endswith(loc_rpath, "index.md") && loc_rpath != "index.md"
+            loc_rpath = replace(loc_rpath, r"index\.md$" => "")
+        end
         if !canonical
             # here we want to remain unix-style, so we don't use joinpath
             # note that rpath never starts with "/" so there's
             # no doubling of "//"
-            rpath = unixify(splitext(locvar("fd_rpath"))[1]) * rpath[3:end]
+            rpath = unixify(splitext(loc_rpath)[1]) * rpath[3:end]
             return "/assets/" * rpath
         else
             if FS2
                 full_path = joinpath(PATHS[:site], "assets",
-                                     splitext(locvar("fd_rpath"))[1],
+                                     splitext(loc_rpath)[1],
                                      join_rpath(rpath[3:end]))
             else
                 full_path = joinpath(PATHS[:assets],

--- a/src/manager/dir_utils.jl
+++ b/src/manager/dir_utils.jl
@@ -275,9 +275,9 @@ function should_ignore(fpath::AS, files2ignore::Vector{String},
                        dirs2ignore::Vector{String})::Bool
     # fpath is necessarily an absolute path so can strip the folder part
     if FD_ENV[:STRUCTURE] < v"0.2"
-        fpath = fpath[length(path(:src))+2:end]
+        fpath = fpath[length(path(:src))+length(PATH_SEP)+1:end]
     else
-        fpath = fpath[length(path(:folder))+2:end]
+        fpath = fpath[length(path(:folder))+length(PATH_SEP)+1:end]
     end
     flag  = findfirst(c -> c == fpath, files2ignore)
     isnothing(flag) || return true

--- a/src/manager/dir_utils.jl
+++ b/src/manager/dir_utils.jl
@@ -102,10 +102,17 @@ Update the dictionaries referring to input files and their time of last change.
 The variable `verb` propagates verbosity.
 """
 function scan_input_dir!(args...; kw...)
+
+    to_ignore = vcat(IGNORE_FILES, globvar("ignore"))
+    # differentiate between files and dirs
+    dir_indicator = [endswith(c, "/") for c in to_ignore]
+    d2i = [d for d in to_ignore[dir_indicator] if length(d) > 1]
+    f2i = filter!((!) ∘ isempty, to_ignore[.!dir_indicator])
+
     if FD_ENV[:STRUCTURE] < v"0.2"
-        return _scan_input_dir!(args...)
+        return _scan_input_dir!(args...; files2ignore=f2i, dirs2ignore=d2i)
     end
-    return _scan_input_dir2!(args...; kw...)
+    return _scan_input_dir2!(args...; files2ignore=f2i, dirs2ignore=d2i, kw...)
 end
 
 function _scan_input_dir!(other_files::TrackedFiles,
@@ -113,12 +120,15 @@ function _scan_input_dir!(other_files::TrackedFiles,
                           md_files::TrackedFiles,
                           html_files::TrackedFiles,
                           literate_files::TrackedFiles,
-                          verb::Bool=false)::Nothing
+                          verb::Bool=false;
+                          files2ignore::Vector{String}=String[],
+                          dirs2ignore::Vector{String}=String[])::Nothing
     # top level files (src/*)
     for file ∈ readdir(PATHS[:src])
-        isfile(joinpath(PATHS[:src], file)) || continue
+        fpath = joinpath(PATHS[:src], file)
+        isfile(fpath) || continue
         # skip if it has to be ignored
-        file ∈ IGNORE_FILES && continue
+        should_ignore(fpath, files2ignore, dirs2ignore) && continue
         fname, fext = splitext(file)
         fpair = (PATHS[:src] => file)
         if file == "config.md"
@@ -132,9 +142,10 @@ function _scan_input_dir!(other_files::TrackedFiles,
     # pages files (src/pages/*)
     for (root, _, files) ∈ walkdir(PATHS[:src_pages])
         for file ∈ files
-            isfile(joinpath(root, file)) || continue
+            fpath = joinpath(root, file)
+            isfile(fpath) || continue
             # skip if it has to be ignored
-            file ∈ IGNORE_FILES && continue
+            should_ignore(fpath, files2ignore, dirs2ignore) && continue
             fname, fext = splitext(file)
             fpair = (root => file)
             if fext == ".md"
@@ -177,7 +188,9 @@ function _scan_input_dir2!(other_files::TrackedFiles,
                            html_pages::TrackedFiles,
                            literate_scripts::TrackedFiles,
                            verb::Bool=false;
-                           in_loop::Bool=false)::Nothing
+                           in_loop::Bool=false,
+                           files2ignore::Vector{String}=String[],
+                           dirs2ignore::Vector{String}=String[])::Nothing
     # go over all files in the website folder
     for (root, _, files) ∈ walkdir(path(:folder))
         for file in files
@@ -189,7 +202,9 @@ function _scan_input_dir2!(other_files::TrackedFiles,
             opts = (fpair, verb, in_loop)
 
             # early skips
-            (!isfile(fpath) || file ∈ IGNORE_FILES) && continue
+            !isfile(fpath) && continue
+            should_ignore(fpath, files2ignore, dirs2ignore) && continue
+
             # skip over `__site` folder, `.git` and `.github` folder
             startswith(fpath, path(:site)) && continue
             startswith(fpath, joinpath(path(:folder), ".git")) && continue
@@ -227,6 +242,8 @@ end
 
 
 """
+$SIGNATURES
+
 Helper function, if `fpair` is not referenced in the dictionary (new file) add
 the entry to the dictionary with the time of last modification as val.
 """
@@ -239,4 +256,32 @@ function add_if_new_file!(dict::TrackedFiles, fpair::Pair{String,String},
     # to force its processing in FS2
     dict[fpair] = ifelse(in_loop, 0, mtime(joinpath(fpair...)))
     return nothing
+end
+
+
+"""
+$SIGNATURES
+
+Check if a file path should be ignored. This is a helper function for the
+`scan_input_dir` functions. A bit of a similar principle to `match_url`. The
+file argument is an absolute path, the list would be a list of relative paths.
+Rules:
+
+* `''` or `'/'`  -> ignore
+* `'path/fname'` -> ignore exactly that
+* `'path/dir/'`  -> ignore everything starting with `path/dir/`
+"""
+function should_ignore(fpath::AS, files2ignore::Vector{String},
+                       dirs2ignore::Vector{String})::Bool
+    # fpath is necessarily an absolute path so can strip the folder part
+    if FD_ENV[:STRUCTURE] < v"0.2"
+        fpath = fpath[length(path(:src))+2:end]
+    else
+        fpath = fpath[length(path(:folder))+2:end]
+    end
+    flag  = findfirst(c -> c == fpath, files2ignore)
+    isnothing(flag) || return true
+    flag  = findfirst(c -> startswith(fpath, c), dirs2ignore)
+    isnothing(flag) || return true
+    return false
 end

--- a/src/manager/post_processing.jl
+++ b/src/manager/post_processing.jl
@@ -282,12 +282,16 @@ removed the local output directory. This will help avoid merge clashes.
 function cleanpull()::Nothing
     FOLDER_PATH[] = pwd()
     set_paths!()
-    if isdir(PATHS[:pub])
-        rmmsg = rpad("→ Removing local output dir...", 35)
-        print(rmmsg)
-        rm(PATHS[:pub], force=true, recursive=true)
-        println("\r" * rmmsg * " [done ✔ ]")
+
+    rmmsg = rpad("→ Removing local __site dir...", 35)
+    print(rmmsg)
+    if FD_ENV[:STRUCTURE] >= v"0.2"
+        isdir(path(:site)) && rm(path(:site), force=true, recursive=true)
+    else
+        isdir(path(:pub)) && rm(path(:pub), force=true, recursive=true)
     end
+    println("\r" * rmmsg * " [done ✔ ]")
+
     try
         pmsg = rpad("→ Retrieving updates from the repository...", 35)
         print(pmsg)

--- a/src/utils/html.jl
+++ b/src/utils/html.jl
@@ -18,7 +18,7 @@ function html_ahref(link::AS, name::Union{Int,AS};
 end
 
 """Convenience function to introduce a hyper reference relative to a key."""
-html_ahref_key(k::AS, n::Union{Int,AS}) = html_ahref(url_curpage() * "#$k", n)
+html_ahref_key(k::AS, n::Union{Int,AS}) = html_ahref("#$k", n)
 
 """Convenience function to introduce a div block."""
 html_div(name::AS, in::AS) = "<div class=\"$name\">$in</div>"

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -15,6 +15,8 @@ const GLOBAL_VARS_DEFAULT = [
     "author"           => Pair("THE AUTHOR",   (String, Nothing)),
     "date_format"      => Pair("U dd, yyyy",   (String,)),
     "prepath"          => Pair("",             (String,)),
+    # will be added to IGNORE_FILES
+    "ignore"           => Pair(String[],       (Vector{String},)),
     # RSS
     "website_title"    => Pair("",             (String,)),
     "website_descr"    => Pair("",             (String,)),
@@ -34,9 +36,6 @@ Re-initialise the global page vars dictionary. (This is done once).
     end
     return nothing
 end
-
-"""Convenience function to get the value associated with a global var."""
-globvar(name::String) = LOCAL_VARS[name].first
 
 """
 Dictionary of variables accessible to the current page. It's initialised with
@@ -114,6 +113,9 @@ end
 
 """Convenience function to get the value associated with a local var."""
 locvar(name::String) = LOCAL_VARS[name].first
+
+"""Convenience function to get the value associated with a global var."""
+globvar(name::String) = GLOBAL_VARS[name].first
 
 """
 Keep track of seen headers. The key is the refstring, the value contains the

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -185,8 +185,16 @@ $(SIGNATURES)
 
 Checks if a data type `t` is a subtype of a tuple of accepted types `tt`.
 """
-check_type(t::DataType, tt::NTuple{N,DataType} where N) =
-    any(<:(t, tᵢ) for tᵢ ∈ tt)
+function check_type(t::DataType, tt::NTuple{N,DataType} where N)::Bool
+    any(valid_subtype(t, tᵢ) for tᵢ ∈ tt) && return true
+    return false
+end
+
+valid_subtype(::Type{T1},
+              ::Type{T2}) where {T1,T2} = T1 <: T2
+valid_subtype(::Type{<:AbstractArray{T1,K}},
+              ::Type{<:AbstractArray{T2,K}}) where {T1,T2,K} = T1 <: T2
+
 
 
 """

--- a/test/converter/hyperref.jl
+++ b/test/converter/hyperref.jl
@@ -35,9 +35,9 @@
         <p>
           Some string
           <a id="$h1"></a>\\[ x = x \\]
-          then as per <span class="bibref"><a href="/index.html#$h2">Amari and Douglas., 1998</a></span>  also this <span class="bibref">(<a href="/index.html#$h3">Bardenet et al., 2017</a>)</span>  and
-          <span class="bibref"><a href="/index.html#$h2">Amari and Douglas., 1998</a>, <a href="/index.html#$h3">Bardenet et al., 2017</a></span>
-          Reference to equation: <span class="eqref">(<a href="/index.html#$h1">1</a>)</span> .
+          then as per <span class="bibref"><a href="#$h2">Amari and Douglas., 1998</a></span>  also this <span class="bibref">(<a href="#$h3">Bardenet et al., 2017</a>)</span>  and
+          <span class="bibref"><a href="#$h2">Amari and Douglas., 1998</a>, <a href="#$h3">Bardenet et al., 2017</a></span>
+          Reference to equation: <span class="eqref">(<a href="#$h1">1</a>)</span> .
         </p>
         <p>
           Then maybe some text etc.
@@ -59,7 +59,7 @@ end
     """
     h = st |> seval
     @test occursin(raw"""<a id="eq_1"></a>\[ x = x \]""", h)
-    @test occursin(raw"""<span class="eqref">(<a href="/index.html#eq_1">1</a>)</span>.""", h)
+    @test occursin(raw"""<span class="eqref">(<a href="#eq_1">1</a>)</span>.""", h)
     @test occursin(raw"""<em>B \(E\)</em>.""", h)
 end
 

--- a/test/converter/markdown.jl
+++ b/test/converter/markdown.jl
@@ -115,9 +115,9 @@ end
         done
         """ |> seval
     @test isapproxstr(h, """
-                        <h1 id="title"><a href="/index.html#title">Title</a></h1>
+                        <h1 id="title"><a href="#title">Title</a></h1>
                         and then
-                        <h2 id="subtitle_cool"><a href="/index.html#subtitle_cool">Subtitle cool&#33;</a></h2>
+                        <h2 id="subtitle_cool"><a href="#subtitle_cool">Subtitle cool&#33;</a></h2>
                         done
                         """)
 end

--- a/test/converter/markdown2.jl
+++ b/test/converter/markdown2.jl
@@ -43,19 +43,19 @@ end
         <div class="franklin-toc">
           <ol>
             <li>
-              <a href="/pub/ff/aa.html#hello_fd">Hello <code>fd</code></a>
+              <a href="#hello_fd">Hello <code>fd</code></a>
               <ol>
-                <li><ol><li><a href="/pub/ff/aa.html#weirdly_nested">weirdly nested</a></li></ol></li>
-                <li><a href="/pub/ff/aa.html#goodbye">Goodbye&#33;</a></li>
+                <li><ol><li><a href="#weirdly_nested">weirdly nested</a></li></ol></li>
+                <li><a href="#goodbye">Goodbye&#33;</a></li>
               </ol>
             </li>
-            <li><a href="/pub/ff/aa.html#done">Done</a></li>
+            <li><a href="#done">Done</a></li>
           </ol>
         </div>
-        <h2 id="hello_fd"><a href="/pub/ff/aa.html#hello_fd">Hello <code>fd</code></a></h2>
-        <h4 id="weirdly_nested"><a href="/pub/ff/aa.html#weirdly_nested">weirdly nested</a></h4>
-        <h3 id="goodbye"><a href="/pub/ff/aa.html#goodbye">Goodbye&#33;</a></h3>
-        <h2 id="done"><a href="/pub/ff/aa.html#done">Done</a></h2>done.
+        <h2 id="hello_fd"><a href="#hello_fd">Hello <code>fd</code></a></h2>
+        <h4 id="weirdly_nested"><a href="#weirdly_nested">weirdly nested</a></h4>
+        <h3 id="goodbye"><a href="#goodbye">Goodbye&#33;</a></h3>
+        <h2 id="done"><a href="#done">Done</a></h2>done.
         """)
 end
 
@@ -77,24 +77,24 @@ end
     @test isapproxstr(s, raw"""
         <div class="franklin-toc">
             <ol>
-                <li><a href="/pub/ff/aa.html#b">B</a>
+                <li><a href="#b">B</a>
                     <ol>
-                        <li><a href="/pub/ff/aa.html#d">D</a></li>
+                        <li><a href="#d">D</a></li>
                     </ol>
                 </li>
-                <li><a href="/pub/ff/aa.html#e">E</a>
+                <li><a href="#e">E</a>
                     <ol>
-                        <li><a href="/pub/ff/aa.html#f">F</a></li>
+                        <li><a href="#f">F</a></li>
                     </ol>
                 </li>
             </ol>
         </div>
-        <h1 id="a"><a href="/pub/ff/aa.html#a">A</a></h1>
-        <h2 id="b"><a href="/pub/ff/aa.html#b">B</a></h2>
-        <h4 id="c"><a href="/pub/ff/aa.html#c">C</a></h4>
-        <h3 id="d"><a href="/pub/ff/aa.html#d">D</a></h3>
-        <h2 id="e"><a href="/pub/ff/aa.html#e">E</a></h2>
-        <h3 id="f"><a href="/pub/ff/aa.html#f">F</a></h3> done.
+        <h1 id="a"><a href="#a">A</a></h1>
+        <h2 id="b"><a href="#b">B</a></h2>
+        <h4 id="c"><a href="#c">C</a></h4>
+        <h3 id="d"><a href="#d">D</a></h3>
+        <h2 id="e"><a href="#e">E</a></h2>
+        <h3 id="f"><a href="#f">F</a></h3> done.
         """)
 end
 
@@ -113,19 +113,19 @@ end
         <div class="franklin-toc">
           <ol>
             <li>
-              <a href="/pages/ff/aa/index.html#hello_fd">Hello <code>fd</code></a>
+              <a href="#hello_fd">Hello <code>fd</code></a>
               <ol>
-                <li><ol><li><a href="/pages/ff/aa/index.html#weirdly_nested">weirdly nested</a></li></ol></li>
-                <li><a href="/pages/ff/aa/index.html#goodbye">Goodbye&#33;</a></li>
+                <li><ol><li><a href="#weirdly_nested">weirdly nested</a></li></ol></li>
+                <li><a href="#goodbye">Goodbye&#33;</a></li>
               </ol>
             </li>
-            <li><a href="/pages/ff/aa/index.html#done">Done</a></li>
+            <li><a href="#done">Done</a></li>
           </ol>
         </div>
-        <h2 id="hello_fd"><a href="/pages/ff/aa/index.html#hello_fd">Hello <code>fd</code></a></h2>
-        <h4 id="weirdly_nested"><a href="/pages/ff/aa/index.html#weirdly_nested">weirdly nested</a></h4>
-        <h3 id="goodbye"><a href="/pages/ff/aa/index.html#goodbye">Goodbye&#33;</a></h3>
-        <h2 id="done"><a href="/pages/ff/aa/index.html#done">Done</a></h2>done.
+        <h2 id="hello_fd"><a href="#hello_fd">Hello <code>fd</code></a></h2>
+        <h4 id="weirdly_nested"><a href="#weirdly_nested">weirdly nested</a></h4>
+        <h3 id="goodbye"><a href="#goodbye">Goodbye&#33;</a></h3>
+        <h2 id="done"><a href="#done">Done</a></h2>done.
         """)
 end
 
@@ -147,23 +147,23 @@ end
     @test isapproxstr(s, raw"""
         <div class="franklin-toc">
             <ol>
-                <li><a href="/pages/ff/aa/index.html#b">B</a>
+                <li><a href="#b">B</a>
                     <ol>
-                        <li><a href="/pages/ff/aa/index.html#d">D</a></li>
+                        <li><a href="#d">D</a></li>
                     </ol>
                 </li>
-                <li><a href="/pages/ff/aa/index.html#e">E</a>
+                <li><a href="#e">E</a>
                     <ol>
-                        <li><a href="/pages/ff/aa/index.html#f">F</a></li>
+                        <li><a href="#f">F</a></li>
                     </ol>
                 </li>
             </ol>
         </div>
-        <h1 id="a"><a href="/pages/ff/aa/index.html#a">A</a></h1>
-        <h2 id="b"><a href="/pages/ff/aa/index.html#b">B</a></h2>
-        <h4 id="c"><a href="/pages/ff/aa/index.html#c">C</a></h4>
-        <h3 id="d"><a href="/pages/ff/aa/index.html#d">D</a></h3>
-        <h2 id="e"><a href="/pages/ff/aa/index.html#e">E</a></h2>
-        <h3 id="f"><a href="/pages/ff/aa/index.html#f">F</a></h3> done.
+        <h1 id="a"><a href="#a">A</a></h1>
+        <h2 id="b"><a href="#b">B</a></h2>
+        <h4 id="c"><a href="#c">C</a></h4>
+        <h3 id="d"><a href="#d">D</a></h3>
+        <h2 id="e"><a href="#e">E</a></h2>
+        <h3 id="f"><a href="#f">F</a></h3> done.
         """)
 end

--- a/test/eval/extras.jl
+++ b/test/eval/extras.jl
@@ -1,0 +1,47 @@
+fs2()
+
+@testset "fig/rpath" begin
+    gotd()
+
+    mkpath(joinpath(td, "__site", "assets", "index"))
+    write(joinpath(td, "__site", "assets", "index", "baz.png"), "baz")
+
+    mkpath(joinpath(td, "__site", "assets", "blog", "kaggle"))
+    write(joinpath(td, "__site", "assets", "blog", "kaggle", "foo.png"), "foo")
+
+    s = raw"""
+        @def fd_rpath = "index.md"
+        ABC
+        \fig{./baz.png}
+        """ |> fd2html_td
+    @test isapproxstr(s, """
+        <p>ABC <img src="/assets/index/baz.png" alt=""></p>
+        """)
+
+    s = raw"""
+        @def fd_rpath = "index.md"
+        ABC
+        \fig{./unknown.png}
+        """ |> fd2html_td
+    @test isapproxstr(s, """
+        <p>ABC <p><span style="color:red;">// Image matching '/assets/index/unknown.png' not found. //</span></p></p>
+        """)
+
+    s = raw"""
+        @def fd_rpath = "blog/kaggle/index.md"
+        ABC
+        \fig{./foo.png}
+        """ |> fd2html_td
+    @test isapproxstr(s, """
+        <p>ABC <img src="/assets/blog/kaggle/foo.png" alt=""></p>
+        """)
+
+    s = raw"""
+        @def fd_rpath = "blog/kaggle/index.md"
+        ABC
+        \fig{./baz.png}
+        """ |> fd2html_td
+    @test isapproxstr(s, """
+        <p>ABC <p><span style="color:red;">// Image matching '/assets/blog/kaggle/baz.png' not found. //</span></p></p>
+        """)
+end

--- a/test/global/cases2.jl
+++ b/test/global/cases2.jl
@@ -79,12 +79,12 @@ end
 
     if VERSION >= v"1.4.0-"
         @test isapproxstr(st |> seval, raw"""<p>A</p>
-<h3 id="title"><a href="/pub/pg1.html#title">Title</a></h3>
+<h3 id="title"><a href="#title">Title</a></h3>
 <table><tr><th align="center">No.</th><th align="center">Graph</th><th align="center">Vertices</th><th align="center">Edges</th></tr><tr><td align="center">1</td><td align="center">Twitter Social Circles</td><td align="center">81,306</td><td align="center">1,342,310</td></tr><tr><td align="center">2</td><td align="center">Astro-Physics Collaboration</td><td align="center">17,903</td><td align="center">197,031</td></tr><tr><td align="center">3</td><td align="center">Facebook Social Circles</td><td align="center">4,039</td><td align="center">88,234</td></tr></table>
 <p>C</p>""")
     else
         @test isapproxstr(st |> seval, raw""" <p>A</p>
-            <h3 id="title"><a href="/pub/pg1.html#title">Title</a></h3>
+            <h3 id="title"><a href="#title">Title</a></h3>
 
             <table>
               <tr>
@@ -125,12 +125,12 @@ end
 
     if VERSION >= v"1.4.0-"
         @test isapproxstr(st |> seval, raw"""<p>A</p>
-<h3 id="title"><a href="/pages/pg1/index.html#title">Title</a></h3>
+<h3 id="title"><a href="#title">Title</a></h3>
 <table><tr><th align="center">No.</th><th align="center">Graph</th><th align="center">Vertices</th><th align="center">Edges</th></tr><tr><td align="center">1</td><td align="center">Twitter Social Circles</td><td align="center">81,306</td><td align="center">1,342,310</td></tr><tr><td align="center">2</td><td align="center">Astro-Physics Collaboration</td><td align="center">17,903</td><td align="center">197,031</td></tr><tr><td align="center">3</td><td align="center">Facebook Social Circles</td><td align="center">4,039</td><td align="center">88,234</td></tr></table>
 <p>C</p>""")
     else
         @test isapproxstr(st |> seval, raw""" <p>A</p>
-            <h3 id="title"><a href="/pages/pg1/index.html#title">Title</a></h3>
+            <h3 id="title"><a href="#title">Title</a></h3>
 
             <table>
               <tr>
@@ -159,5 +159,5 @@ end
     etc
     ~~~{{fill title}}~~~
     """ |> fd2html_td
-    @test isapproxstr(s, raw"""<h1 id="aaa"><a href="/index.html#aaa">AAA</a></h1>  etc AAA""")
+    @test isapproxstr(s, raw"""<h1 id="aaa"><a href="#aaa">AAA</a></h1>  etc AAA""")
 end

--- a/test/integration/literate.jl
+++ b/test/integration/literate.jl
@@ -90,7 +90,7 @@ end
         \literate{/_literate/tutorial.jl}
         """ |> fd2html_td
     @test isapproxstr(h, """
-        <h1 id="rational_numbers"><a href="/index.html#rational_numbers">Rational numbers</a></h1>
+        <h1 id="rational_numbers"><a href="#rational_numbers">Rational numbers</a></h1>
         <p>In julia rational numbers can be constructed with the <code>//</code> operator. Lets define two rational numbers, <code>x</code> and <code>y</code>:</p>
         <pre><code class="language-julia"># Define variable x and y
         x = 1//3

--- a/test/integration/literate_fs2.jl
+++ b/test/integration/literate_fs2.jl
@@ -91,7 +91,7 @@ end
         \literate{/literate-scripts/tutorial.jl}
         """ |> fd2html_td
     @test isapproxstr(h, """
-        <h1 id="rational_numbers"><a href="/index.html#rational_numbers">Rational numbers</a></h1>
+        <h1 id="rational_numbers"><a href="#rational_numbers">Rational numbers</a></h1>
         <p>In julia rational numbers can be constructed with the <code>//</code> operator. Lets define two rational numbers, <code>x</code> and <code>y</code>:</p>
         <pre><code class="language-julia"># Define variable x and y
         x = 1//3

--- a/test/manager/config_fs2.jl
+++ b/test/manager/config_fs2.jl
@@ -32,3 +32,20 @@ foofig(s) = (write(joinpath(td, "config.md"), s); F.process_config())
 
     @test fd2html(raw"""\helloc"""; dir=td, internal=true) == "goodbye"
 end
+
+@testset "i381" begin
+    foofig(raw"""
+        @def tags = []
+        """)
+
+    s = """
+        @def tags = ["tag1", "tag2"]
+
+        ~~~
+        {{for tag in tags}}
+        {{fill tag}}
+        {{end}}
+        ~~~
+        """ |> fd2html_td
+    @test isapproxstr(s, "tag1 tag2")
+end

--- a/test/manager/dir_utils.jl
+++ b/test/manager/dir_utils.jl
@@ -1,0 +1,53 @@
+fs2()
+
+@testset "ignore/fs2" begin
+    gotd()
+    s = """
+        @def ignore = ["foo.md", "path/foo.md", "dir/", "path/dir/"]
+        """
+    write(joinpath(td, "config.md"), s);
+    F.process_config()
+    @test F.globvar("ignore") == ["foo.md", "path/foo.md", "dir/", "path/dir/"]
+
+    write(joinpath(td, "foo.md"), "anything")
+    mkpath(joinpath(td, "path"))
+    write(joinpath(td, "path", "foo.md"), "anything")
+    mkpath(joinpath(td, "dir"))
+    write(joinpath(td, "dir", "foo1.md"), "anything")
+    mkpath(joinpath(td, "path", "dir"))
+    write(joinpath(td, "path", "dir", "foo2.md"), "anything")
+    write(joinpath(td, "index.md"), "standard things")
+    watched = F.fd_setup()
+    @test length(watched.md) == 1
+    @test first(watched.md).first.second == "index.md"
+end
+
+fs1()
+
+@testset "ignore/fs1" begin
+    gotd()
+    s = """
+        @def ignore = ["foo.md", "path/foo.md", "dir/", "path/dir/"]
+        """
+    mkpath(joinpath(td, "src"))
+    write(joinpath(td, "src", "config.md"), s);
+    F.process_config()
+    @test F.globvar("ignore") == ["foo.md", "path/foo.md", "dir/", "path/dir/"]
+
+    write(joinpath(td, "src", "foo.md"), "anything")
+    mkpath(joinpath(td, "src", "path"))
+    write(joinpath(td, "src", "path", "foo.md"), "anything")
+    mkpath(joinpath(td, "src", "dir"))
+    write(joinpath(td, "src", "dir", "foo1.md"), "anything")
+    mkpath(joinpath(td, "src", "path", "dir"))
+    write(joinpath(td, "src", "path", "dir", "foo2.md"), "anything")
+    write(joinpath(td, "src", "index.md"), "standard things")
+
+    mkpath(joinpath(td, "src", "pages"))
+    mkpath(joinpath(td, "src", "_css"))
+    mkpath(joinpath(td, "src", "_html_parts"))
+
+    watched = F.fd_setup()
+    @test length(watched.md) == 1
+    @test first(watched.md).first.second == "index.md"
+end

--- a/test/parser/footnotes+links.jl
+++ b/test/parser/footnotes+links.jl
@@ -4,8 +4,8 @@
         A[^1] B[^blah] C
         """
     @test isapproxstr(st |> seval, """
-           <p>A<sup id="fnref:1"><a href="/index.html#fndef:1" class="fnref">[1]</a></sup>
-              B<sup id="fnref:blah"><a href="/index.html#fndef:blah" class="fnref">[2]</a></sup>
+           <p>A<sup id="fnref:1"><a href="#fndef:1" class="fnref">[1]</a></sup>
+              B<sup id="fnref:blah"><a href="#fndef:blah" class="fnref">[2]</a></sup>
               C</p>""")
 
     st = """
@@ -17,18 +17,18 @@
     @test isapproxstr(st |> seval, """
             <p>
                 A
-                <sup id="fnref:1"><a href="/index.html#fndef:1" class="fnref">[1]</a></sup>
-                B<sup id="fnref:blah"><a href="/index.html#fndef:blah" class="fnref">[2]</a></sup>
+                <sup id="fnref:1"><a href="#fndef:1" class="fnref">[1]</a></sup>
+                B<sup id="fnref:blah"><a href="#fndef:blah" class="fnref">[2]</a></sup>
                 C
                 <table class="fndef" id="fndef:1">
                 <tr>
-                    <td class="fndef-backref"><a href="/index.html#fnref:1">[1]</a></td>
+                    <td class="fndef-backref"><a href="#fnref:1">[1]</a></td>
                     <td class="fndef-content">first footnote</td>
                 </tr>
                 </table>
                 <table class="fndef" id="fndef:blah">
                     <tr>
-                        <td class="fndef-backref"><a href="/index.html#fnref:blah">[2]</a></td>
+                        <td class="fndef-backref"><a href="#fnref:blah">[2]</a></td>
                         <td class="fndef-content">second footnote</td>
                     </tr>
                 </table>

--- a/test/parser/markdown+latex.jl
+++ b/test/parser/markdown+latex.jl
@@ -277,17 +277,17 @@ end
         6
         """ |> seval
     @test isapproxstr(h, """
-        <h1 id="t1"><a href="/index.html#t1">t1</a></h1>
+        <h1 id="t1"><a href="#t1">t1</a></h1>
         1
-        <h2 id="t2"><a href="/index.html#t2">t2</a></h2>
+        <h2 id="t2"><a href="#t2">t2</a></h2>
         2
-        <h2 id="t3_blah_etc"><a href="/index.html#t3_blah_etc">t3 <code>blah</code> etc</a></h2>
+        <h2 id="t3_blah_etc"><a href="#t3_blah_etc">t3 <code>blah</code> etc</a></h2>
         3
-        <h3 id="t4"><a href="/index.html#t4">t4 </a></h3>
+        <h3 id="t4"><a href="#t4">t4 </a></h3>
         4
-        <h3 id="t2__2"><a href="/index.html#t2__2">t2</a></h3>
+        <h3 id="t2__2"><a href="#t2__2">t2</a></h3>
         5
-        <h3 id="t2__3"><a href="/index.html#t2__3">t2</a></h3>
+        <h3 id="t2__3"><a href="#t2__3">t2</a></h3>
         6
         """)
 
@@ -301,11 +301,11 @@ end
         C
         """ |> seval
     @test  isapproxstr(h, """
-        <h2 id="example"><a href="/index.html#example">example</a></h2>
+        <h2 id="example"><a href="#example">example</a></h2>
         A
-        <h2 id="example__2"><a href="/index.html#example__2">example</a></h2>
+        <h2 id="example__2"><a href="#example__2">example</a></h2>
         B
-        <h2 id="example_2"><a href="/index.html#example_2">example 2</a></h2>
+        <h2 id="example_2"><a href="#example_2">example 2</a></h2>
         C
         """)
 end
@@ -319,14 +319,14 @@ end
 
 @testset "Header+lx" begin
     h = "# blah" |> fd2html_td
-    @test h == raw"""<h1 id="blah"><a href="/index.html#blah">blah</a></h1>"""
+    @test h == raw"""<h1 id="blah"><a href="#blah">blah</a></h1>"""
     h = raw"""
         \newcommand{\foo}{foo}
         \newcommand{\header}{# hello}
         \foo
         \header
         """ |> fd2html_td
-    @test h == raw"""foo <h1 id="hello"><a href="/index.html#hello">hello</a></h1>"""
+    @test h == raw"""foo <h1 id="hello"><a href="#hello">hello</a></h1>"""
     h = raw"""
         \newcommand{\foo}{foo}
         \foo hello
@@ -336,11 +336,11 @@ end
         \newcommand{\foo}{blah}
         # \foo hello
         """ |> fd2html_td
-    @test h == raw"""<h1 id="blah_hello"><a href="/index.html#blah_hello">blah hello</a></h1>"""
+    @test h == raw"""<h1 id="blah_hello"><a href="#blah_hello">blah hello</a></h1>"""
     h = raw"""
         \newcommand{\foo}{foo}
         \newcommand{\header}[2]{!#1 \foo #2}
         \header{##}{hello}
         """ |> fd2html_td
-    @test h == raw"""<h2 id="foo_hello"><a href="/index.html#foo_hello">foo  hello</a></h2>"""
+    @test h == raw"""<h2 id="foo_hello"><a href="#foo_hello">foo  hello</a></h2>"""
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ include("manager/utils_fs2.jl")
 include("manager/rss.jl")
 include("manager/config.jl")
 include("manager/config_fs2.jl")
+include("manager/dir_utils.jl")
 println("🍺")
 
 # PARSER folder
@@ -43,6 +44,7 @@ include("eval/codeblock.jl")
 include("eval/eval.jl")
 include("eval/eval_fs2.jl")
 include("eval/integration.jl")
+include("eval/extras.jl")
 
 # CONVERTER folder
 println("CONVERTER/MD")

--- a/test/utils/html.jl
+++ b/test/utils/html.jl
@@ -4,7 +4,7 @@
     set_curpath("pages/cpB/blah.md")
     @test F.html_ahref(λ, 1)           == "<a href=\"$λ\">1</a>"
     @test F.html_ahref(λ, "bb")        == "<a href=\"$λ\">bb</a>"
-    @test F.html_ahref_key("cc", "dd") == "<a href=\"/pub/cpB/blah.html#cc\">dd</a>"
+    @test F.html_ahref_key("cc", "dd") == "<a href=\"#cc\">dd</a>"
     @test F.html_div("dn","ct") == "<div class=\"dn\">ct</div>"
     @test F.html_img("src", "alt") == "<img src=\"src\" alt=\"alt\">"
     @test F.html_code("code") == "<pre><code class=\"plaintext\">code</code></pre>"
@@ -16,7 +16,7 @@
     set_curpath("cpB/blah.md")
     @test F.html_ahref(λ, 1)           == "<a href=\"$λ\">1</a>"
     @test F.html_ahref(λ, "bb")        == "<a href=\"$λ\">bb</a>"
-    @test F.html_ahref_key("cc", "dd") == "<a href=\"/cpB/blah/index.html#cc\">dd</a>"
+    @test F.html_ahref_key("cc", "dd") == "<a href=\"#cc\">dd</a>"
 
     fs1()
 end

--- a/test/utils/misc.jl
+++ b/test/utils/misc.jl
@@ -88,7 +88,7 @@ end
     set_curpath("pages/cpB/blah.md")
     @test F.html_ahref(λ, 1) == "<a href=\"$λ\">1</a>"
     @test F.html_ahref(λ, "bb") == "<a href=\"$λ\">bb</a>"
-    @test F.html_ahref_key("cc", "dd") == "<a href=\"/pub/cpB/blah.html#cc\">dd</a>"
+    @test F.html_ahref_key("cc", "dd") == "<a href=\"#cc\">dd</a>"
     @test F.html_div("dn","ct") == "<div class=\"dn\">ct</div>"
     @test F.html_img("src", "alt") == "<img src=\"src\" alt=\"alt\">"
     @test F.html_code("code") == "<pre><code class=\"plaintext\">code</code></pre>"

--- a/test/utils/misc.jl
+++ b/test/utils/misc.jl
@@ -115,3 +115,13 @@ end
     @test F.match_url("menu1", "menu1")
     @test F.match_url("menu1", "/menu1/*")
 end
+
+@testset "check_type" begin
+    @test F.check_type(Float64, (Real,))
+    @test F.check_type(Float64, (Real, String))
+    @test F.check_type(Int,     (Any,))
+    @test !F.check_type(String, (Real,))
+    @test F.check_type(Vector{Float64}, (Vector{Real},))
+    @test F.check_type(Vector{String},  (Vector{Any},))
+    @test !F.check_type(Vector{String}, (Matrix{Any},))
+end


### PR DESCRIPTION
### New stuff

* adds a `ignore`, works like so (in `config.md`):

```
@def ignore = ["file", "path/file", "dir/", "path/dir/"]
```

which should be self explanatory. No other syntax allowed. An ignored file/folder will also not be copied to `__site`. This closes #376.

### Bug fixes

* Relative path fix with a stray addition of `index` in the new folder structure, closes #377 basically  this in `path/to/page.md`

```
\fig{./fig.png}
```

will try to insert a link to `/assets/path/to/page/fig.png` so, locally, you should put the image at `/_assets/path/to/page/fig.png`.

* internal anchors are now just `"#key"` instead of `URL * #key` which caused page reload (closes #382) 
* fix `cleanpull` when working with the new folder structure, closes #378 
* fix `check_type` for page vars in the presence of arrays, closes #381 