### PR TITLE
closes #412

### DIFF
--- a/src/converter/html/html.jl
+++ b/src/converter/html/html.jl
@@ -50,6 +50,8 @@ function fd2html_v(st::AS; internal::Bool=false,
         def_GLOBAL_VARS!()
         FD_ENV[:CUR_PATH] = "index.md"
     end
+    # corner case if `serve` is used and cleanup has emptied global vars
+    !(@isdefined GLOBAL_VARS) || isempty(GLOBAL_VARS) && def_GLOBAL_VARS!()
     m = convert_md(st; isinternal=internal)
     h = convert_html(m)
     return h, LOCAL_VARS

--- a/src/converter/markdown/md.jl
+++ b/src/converter/markdown/md.jl
@@ -27,14 +27,7 @@ function convert_md(mds::AS,
                     isconfig::Bool=false,
                     has_mddefs::Bool=true )::String
     # instantiate page dictionaries
-    if !(isrecursive || isinternal)
-        def_LOCAL_VARS!()       # page-specific variables
-        def_PAGE_HEADERS!()     # all the headers
-        def_PAGE_EQREFS!()      # page-specific equation dict (hrefs)
-        def_PAGE_BIBREFS!()     # page-specific reference dict (hrefs)
-        def_PAGE_FNREFS!()      # page-specific footnote dict
-        def_PAGE_LINK_DEFS!()   # page-specific link definition candidates
-    end
+    isrecursive || isinternal || set_page_env()
     # if we're given a substring, force it to a string
     mds = String(mds)
 

--- a/src/manager/file_utils.jl
+++ b/src/manager/file_utils.jl
@@ -155,6 +155,7 @@ function process_file_err(
                    prerender=prerender, isoptim=isoptim, on_write=on_write)
     elseif case == :html
         set_cur_rpath(joinpath(fpair...))
+        set_page_env()
         raw_html  = read(inp, String)
         proc_html = convert_html(raw_html; isoptim=isoptim)
         write(outp, proc_html)

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -261,3 +261,19 @@ function set_vars!(vars::PageVars, assignments::Vector{Pair{String,String}}
     end
     return vars
 end
+
+
+"""
+    set_page_env()
+
+Initialises all page dictionaries.
+"""
+function set_page_env()
+    def_LOCAL_VARS!()       # page-specific variables
+    def_PAGE_HEADERS!()     # all the headers
+    def_PAGE_EQREFS!()      # page-specific equation dict (hrefs)
+    def_PAGE_BIBREFS!()     # page-specific reference dict (hrefs)
+    def_PAGE_FNREFS!()      # page-specific footnote dict
+    def_PAGE_LINK_DEFS!()   # page-specific link definition candidates
+    return nothing
+end

--- a/test/manager/page_vars_html.jl
+++ b/test/manager/page_vars_html.jl
@@ -1,0 +1,24 @@
+fs2()
+
+@testset "Scope (#412)" begin
+    write(joinpath(td, "config.md"), """
+        @def title = "config"
+        """)
+    write(joinpath(td, "page.md"), """
+        @def title = "page"
+        """)
+    write(joinpath(td, "index.html"), """
+        {{insert head.html}}
+        """)
+    mkpath(joinpath(td, "_layout"))
+    mkpath(joinpath(td, "_css"))
+    write(joinpath(td, "_layout", "head.html"), "<h1>{{fill title}}</h1>")
+    write(joinpath(td, "_layout", "page_foot.html"), "")
+    write(joinpath(td, "_layout", "foot.html"), "")
+    serve(single=true)
+
+    @test startswith(read(joinpath("__site", "index.html"), String),
+                        "<h1>config</h1>")
+    @test startswith(read(joinpath("__site", "page", "index.html"), String),
+                        "<h1>page</h1>")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ include("manager/rss.jl")
 include("manager/config.jl")
 include("manager/config_fs2.jl")
 include("manager/dir_utils.jl")
+include("manager/page_vars_html.jl")
 println("🍺")
 
 # PARSER folder


### PR DESCRIPTION
Ensures that when processing source `*.html` files they have their own page environments (and don't steal another page's). 

This will also be useful for #407 where the MD  blocks should have access to that scope.