### PR TITLE
Make locvar/globvar return nothing instead of erroring

### DIFF
--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -111,11 +111,17 @@ function def_LOCAL_VARS!()::Nothing
     return nothing
 end
 
-"""Convenience function to get the value associated with a local var."""
-locvar(name::String) = LOCAL_VARS[name].first
+"""
+Convenience function to get the value associated with a local var.
+Return `nothing` if the variable is not found.
+"""
+locvar(name::String) = haskey(LOCAL_VARS, name) ? LOCAL_VARS[name].first : nothing
 
-"""Convenience function to get the value associated with a global var."""
-globvar(name::String) = GLOBAL_VARS[name].first
+"""
+Convenience function to get the value associated with a global var.
+Return `nothing` if the variable is not found.
+"""
+globvar(name::String) = haskey(GLOBAL_VARS, name) ? GLOBAL_VARS[name].first : nothing
 
 """
 Keep track of seen headers. The key is the refstring, the value contains the

--- a/test/converter/md_defs.jl
+++ b/test/converter/md_defs.jl
@@ -87,4 +87,6 @@ end
         """ |> fd2html_td
     @test isapproxstr(F.locvar("s"), "foo bar baz etc")
     @test isapproxstr(F.locvar("s2"), "nothing")
+    @test F.locvar("foobar") === nothing
+    @test F.globvar("foobar") === nothing
 end


### PR DESCRIPTION
Make locvar/globvar return nothing instead of erroring if the variable is not defined. Should be non-breaking since this used to error.