### PR TITLE
corner case fix for previous PR

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.6.10"
+version = "0.6.11"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/parser/markdown/tokens.jl
+++ b/src/parser/markdown/tokens.jl
@@ -160,8 +160,10 @@ const MD_OCB = [
     OCProto(:H3,              :H3_OPEN,      L_RETURNS,     false),
     OCProto(:H4,              :H4_OPEN,      L_RETURNS,     false),
     OCProto(:H5,              :H5_OPEN,      L_RETURNS,     false),
-    OCProto(:H6,              :H6_OPEN,      L_RETURNS,     false),
-    # ------------------------------------------------------------------
+    OCProto(:H6,              :H6_OPEN,      L_RETURNS,     false)
+    ]
+# the split is due to double brace blocks being allowed in markdown
+const MD_OCB2 = [
     OCProto(:LXB,             :LXB_OPEN,     (:LXB_CLOSE,), true ),
     OCProto(:DIV,             :DIV_OPEN,     (:DIV_CLOSE,), true ),
     ]
@@ -223,7 +225,7 @@ MD_OCB_ALL
 
 Combination of all `MD_OCB` in order.
 """
-const MD_OCB_ALL = vcat(MD_OCB, MD_OCB_MATH) # order matters
+const MD_OCB_ALL = vcat(MD_OCB, MD_OCB2, MD_OCB_MATH) # order matters
 
 
 """

--- a/src/parser/ocblocks.jl
+++ b/src/parser/ocblocks.jl
@@ -11,7 +11,7 @@ function find_ocblocks(tokens::Vector{Token}, ocproto::OCProto;
 
     ntokens       = length(tokens)
     active_tokens = ones(Bool, length(tokens))
-    ocblocks      = Vector{OCBlock}()
+    ocblocks      = OCBlock[]
     nestable      = ocproto.nest
 
     # go over active tokens check if there's an opening token

--- a/test/parser/markdown-extra.jl
+++ b/test/parser/markdown-extra.jl
@@ -117,5 +117,11 @@ end
         @def title = "hello"
         {{title}}{{title}}
         """ |> fd2html_td
-    @test isapproxstr(s, "<p>hellohello</p>")
+    @test isapproxstr(s, "hellohello")
+    s = """
+        @def a_b = "hello"
+        @def c_d = "goodbye"
+        {{a_b}}{{c_d}}
+        """ |> fd2html_td
+    @test isapproxstr(s, "hellogoodbye")
 end


### PR DESCRIPTION
This is a patch fix for the previous PR #422 . It's a bit of a silly mistake, the way I was processing these "double brace blocks" was the laziest possible: basically just leave them as such and let the HTML converter deal with them.

The issue is that if it contains an `_` in the name, then possibly `Markdown.html` will introduce `<em>` or `</em>` in there. So in fact you have  to escape these blocks.

This PR does (just) this, unfortunately there is an ambiguity with `LXB` (latex brace blocks) which has to be avoided so this is not a completely trivial PR.