### PR TITLE
I424

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.6.11"
+version = "0.6.12"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/parser/markdown/validate.jl
+++ b/src/parser/markdown/validate.jl
@@ -142,7 +142,8 @@ function find_double_brace_blocks(tokens)
         thead = tokens[head]
         if thead.name in (:LXB_OPEN, :LXB_CLOSE)
             tcand = tokens[head+1]
-            if tcand.name == thead.name
+            nhead = nextind(str(thead), to(thead))
+            if from(tcand) == nhead && tcand.name == thead.name
                 name = ifelse(thead.name == :LXB_OPEN, :DB_OPEN, :DB_CLOSE)
                 ss   = subs(str(thead), from(thead), to(tcand))
                 push!(db_tokens, Token(name, ss, 0))

--- a/test/parser/markdown-extra.jl
+++ b/test/parser/markdown-extra.jl
@@ -125,3 +125,14 @@ end
         """ |> fd2html_td
     @test isapproxstr(s, "hellogoodbye")
 end
+
+# issue 424 with double braces
+@testset "Double brace2" begin
+    s = raw"""
+        @def title = "hello"
+        {{title}}
+        $\rho=\frac{e^{-\beta \mathcal{E}_{s}}} {\mathcal{Z}} $
+        """ |> fd2html_td
+    @test isapproxstr(s, """
+        hello \\(\\rho=\\frac{e^{-\\beta \\mathcal{E}_{s}}} {\\mathcal{Z}} \\)""")
+end


### PR DESCRIPTION
Closes #424 

#423 and #422 introduces the possibility to  parse `{{ ... }}` blocks directly from markdown, the detection of the `{{` checked if two tokens `{` (`LXB_OPEN`) were one after the other but didn't check whether they were _right after the other_ (i.e. no char in between). This means that with math equations with several opening `{` with some stuff in between like in #424, it processed things as if it was a `{{...}}` block 🙄 