### PR TITLE
Closes #430 (special character in footnotedef)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.6.13"
+version = "0.6.14"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/parser/latex/tokens.jl
+++ b/src/parser/latex/tokens.jl
@@ -1,30 +1,4 @@
 """
-LX_NAME_PAT
-
-Regex to find the name in a new command within a brace block. For example:
-
-    \\newcommand{\\com}[2]{def}
-
-will give as first capture group `\\com`.
-"""
-const LX_NAME_PAT = r"^\s*(\\[a-zA-Z]+)\s*$"
-
-
-"""
-LX_NARG_PAT
-
-Regex to find the number of argument in a new command (if it is given). For
-example:
-
-    \\newcommand{\\com}[2]{def}
-
-will give as second capture group `2`. If there are no number of arguments, the
-second capturing group will be `nothing`.
-"""
-const LX_NARG_PAT = r"\s*(\[\s*(\d)\s*\])?\s*"
-
-
-"""
 LX_TOKENS
 
 List of names of latex tokens. (See markdown tokens)

--- a/src/parser/markdown/tokens.jl
+++ b/src/parser/markdown/tokens.jl
@@ -108,15 +108,6 @@ const MD_TOKENS_LX = Dict{Char, Vector{TokenFinder}}(
         incrlook((_, c) -> α(c)) => :LX_COMMAND ]
     )
 
-"""
-    ASSIGN_PAT
-
-Regex to match 'var' in an assignment of the form
-
-    var = value
-"""
-const ASSIGN_PAT = r"^([a-zA-Z_]\S*)\s*?=((?:.|\n)*)"
-
 
 """
 L_RETURNS

--- a/src/parser/markdown/validate.jl
+++ b/src/parser/markdown/validate.jl
@@ -2,8 +2,8 @@
 $SIGNATURES
 
 Find footnotes refs and defs and eliminate the ones that don't verify the
-appropriate regex. For a footnote ref: `\\[\\^[a-zA-Z0-0]+\\]` and
-`\\[\\^[a-zA-Z0-0]+\\]:` for the def.
+appropriate regex. For a footnote ref: `\\[\\^[\\p{L}0-0]+\\]` and
+`\\[\\^[\\p{L}0-0]+\\]:` for the def.
 """
 function validate_footnotes!(tokens::Vector{Token})
     fn_refs = Vector{Token}()
@@ -11,7 +11,7 @@ function validate_footnotes!(tokens::Vector{Token})
     for (i, τ) in enumerate(tokens)
         τ.name == :FOOTNOTE_REF || continue
         # footnote ref [^1]:
-        m = match(r"^\[\^[a-zA-Z0-9]+\](:)?$", τ.ss)
+        m = match(FN_DEF_PAT, τ.ss)
         if !isnothing(m)
             if !isnothing(m.captures[1])
                 # it's a def

--- a/src/parser/tokens.jl
+++ b/src/parser/tokens.jl
@@ -276,7 +276,7 @@ is_html_entity(i::Int, c::Char) = αη(c, ('#',';'))
 """
 $(SIGNATURES)
 
-Check if it looks like `\\[\\^[a-zA-Z0-9]+\\]:`.
+Check if it looks like `\\[\\^[\\p{L}0-9]+\\]:`.
 """
 function is_footnote(i::Int, c::Char)
     i == 1 && return c == '^'

--- a/src/regexes.jl
+++ b/src/regexes.jl
@@ -1,11 +1,54 @@
 #= =====================================================
-LINK patterns, see html link fixer
+LATEX patterns, see html link fixer, validate_footnotes
+===================================================== =#
+
+"""
+LX_NAME_PAT
+
+Regex to find the name in a new command within a brace block. For example:
+
+    \\newcommand{\\com}[2]{def}
+
+will give as first capture group `\\com`.
+"""
+const LX_NAME_PAT = r"^\s*(\\[\p{L}]+)\s*$"
+
+
+"""
+LX_NARG_PAT
+
+Regex to find the number of argument in a new command (if it is given). For
+example:
+
+    \\newcommand{\\com}[2]{def}
+
+will give as second capture group `2`. If there are no number of arguments, the
+second capturing group will be `nothing`.
+"""
+const LX_NARG_PAT = r"\s*(\[\s*(\d)\s*\])?\s*"
+
+#= =====================================================
+MDDEF patterns
+===================================================== =#
+"""
+    ASSIGN_PAT
+
+Regex to match 'var' in an assignment of the form
+
+    var = value
+"""
+const ASSIGN_PAT = r"^([\p{L}_]\S*)\s*?=((?:.|\n)*)"
+
+#= =====================================================
+LINK patterns, see html link fixer, validate_footnotes
 ===================================================== =#
 # here we're looking for [id] or [id][] or [stuff][id] or ![stuff][id] but not [id]:
 # 1 > (&#33;)? == either ! or nothing
 # 2 > &#91;(.*?)&#93; == [...] inside of the brackets
 # 3 > (?:&#91;(.*?)&#93;)? == [...] inside of second brackets if there is such
 const ESC_LINK_PAT = r"(&#33;)?&#91;(.*?)&#93;(?!:)(?:&#91;(.*?)&#93;)?"
+
+const FN_DEF_PAT = r"^\[\^[\p{L}0-9_]+\](:)?$"
 
 #= =====================================================
 HBLOCK patterns, see html blocks
@@ -17,7 +60,7 @@ NOTE: the for block needs verification (matching parens)
 ===================================================== =#
 const HBO = raw"(?:{{|&#123;&#123;)\s*"
 const HBC = raw"\s*(?:}}|&#125;&#125;)"
-const VAR = raw"([a-zA-Z_]\S*)"
+const VAR = raw"([\p{L}_]\S*)"
 const ANY = raw"((.|\n)+?)"
 
 const HBLOCK_IF_PAT     = Regex(HBO * raw"if\s+" * VAR * HBC)
@@ -39,7 +82,7 @@ where `iterate` is an iterator
 """
 const HBLOCK_FOR_PAT = Regex(
         HBO * raw"for\s+" *
-        raw"(\(?(?:\s*[a-zA-Z_][^\r\n\t\f\v,]*,\s*)*[a-zA-Z_]\S*\s*\)?)" *
+        raw"(\(?(?:\s*[\p{L}_][^\r\n\t\f\v,]*,\s*)*[\p{L}_]\S*\s*\)?)" *
         raw"\s+in\s+" * VAR * HBC)
 
 """

--- a/src/utils/misc.jl
+++ b/src/utils/misc.jl
@@ -147,7 +147,7 @@ function refstring(s::AS)::String
     st = replace(s, r"<[a-z\/]+>"=>"")
     # remove non-word characters
     st = replace(st, r"&#[0-9]+;" => "")
-    st = replace(st, r"[^a-zA-Z0-9_\-\s]" => "")
+    st = replace(st, r"[^\p{L}0-9_\-\s]" => "")
     # replace spaces by dashes
     st = replace(lowercase(strip(st)), r"\s+" => "_")
     # to avoid clashes with numbering of repeated headers, replace

--- a/test/global/cases2.jl
+++ b/test/global/cases2.jl
@@ -161,3 +161,21 @@ end
     """ |> fd2html_td
     @test isapproxstr(s, raw"""<h1 id="aaa"><a href="#aaa">AAA</a></h1>  etc AAA""")
 end
+
+@testset "i 430" begin
+    s = raw"""
+        Hello[^ö]
+
+        [^ö]: world
+        """ |> fd2html_td
+    @test isapproxstr(s, """
+        <p>Hello<sup id="fnref:ö"><a href="#fndef:ö" class="fnref">[1]</a></sup>
+        <table class="fndef" id="fndef:ö">
+          <tr>
+            <td class="fndef-backref"><a href="#fnref:ö">[1]</a></td>
+            <td class="fndef-content">world</td>
+          </tr>
+        </table>
+        </p>
+        """)
+end

--- a/test/regexes.jl
+++ b/test/regexes.jl
@@ -1,4 +1,42 @@
-### ESC LINK
+### LX_PAT
+@testset "latex" begin
+    for s in (
+            raw"\com",
+            raw"  \com ",
+        )
+        m = match(F.LX_NAME_PAT, s)
+        @test m.captures[1] == raw"\com"
+    end
+    for s in (
+            raw"\cöm",
+            raw"  \cöm ",
+        )
+        m = match(F.LX_NAME_PAT, s)
+        @test m.captures[1] == raw"\cöm"
+    end
+    for s in (
+            raw"[2]",
+            raw" [2] ",
+            raw" [ 2]",
+            raw" [ 2 ] "
+        )
+        m = match(F.LX_NARG_PAT, s)
+        @test m.captures[2] == "2"
+    end
+end
+
+### Assign pat
+@testset "assign" begin
+    for s in (
+            raw"cöm_012 = blah",
+        )
+        m = match(F.ASSIGN_PAT, s)
+        @test m.captures[1] == raw"cöm_012"
+        @test strip(m.captures[2]) == raw"blah"
+    end
+end
+
+### LINK
 @testset "esclink" begin
     s = Markdown.htmlesc("[hello]")
     a,b,c = match(F.ESC_LINK_PAT, s).captures
@@ -22,6 +60,15 @@
     @test c == "id"
     s = Markdown.htmlesc("[hello]:")
     @test isnothing(match(F.ESC_LINK_PAT, s))
+end
+
+@testset "fndef" begin
+    for s in (
+            raw"[^örα_01]:",
+        )
+        m = match(F.FN_DEF_PAT, s)
+        @test !isnothing(m)
+    end
 end
 
 ### HBLOCK REGEXES


### PR DESCRIPTION
Now:

```
julia> """
              Hello[^ö]

              [^ö]: world
              """ |> fd2html
```

basically gives

```
<p>Hello<sup id="fnref:ö"><a href="#fndef:ö" class="fnref">[1]</a></sup>
<table class="fndef" id="fndef:ö">
  <tr>
    <td class="fndef-backref"><a href="#fnref:ö">[1]</a></td>
    <td class="fndef-content">world</td>
  </tr>
</table>
</p>
```

as would be expected.