### PR TITLE
Add language customization to dates

### DIFF
--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -184,6 +184,8 @@ Convenience functions related to the page vars
 ============================================= =#
 
 """
+$(SIGNATURES)
+
 Convenience function taking a `DateTime` object and returning the corresponding
 formatted string with the format contained in `LOCAL_VARS["date_format"]` and 
 with the locale data provided in `date_months`, `date_shortmonths`, `date_days`, 
@@ -193,11 +195,11 @@ automatically construct them using the first three letters of the names in
 """
 function fd_date(d::DateTime)
     # aliases for locale data and format from local variables
-    format      = LOCAL_VARS["date_format"].first
-    months      = LOCAL_VARS["date_months"].first
-    shortmonths = LOCAL_VARS["date_shortmonths"].first
-    days        = LOCAL_VARS["date_days"].first
-    shortdays   = LOCAL_VARS["date_shortdays"].first
+    format      = locvar("date_format")
+    months      = locvar("date_months")
+    shortmonths = locvar("date_shortmonths")
+    days        = locvar("date_days")
+    shortdays   = locvar("date_shortdays")
     # if vectors are empty, user has not defined custom locale,
     # defaults to english
     if all(isempty.((months, shortmonths, days, shortdays)))
@@ -205,11 +207,11 @@ function fd_date(d::DateTime)
     end
     # if shortdays or shortmonths are undefined,
     # automatically construct them from other lists
-    if !isempty(days) || isempty(shortdays)
-        shortdays = [length(d) >= 3 ? d[1:3] : d for d ∈ days]
+    if !isempty(days) && isempty(shortdays)
+        shortdays = first.(days, 3)
     end
-    if !isempty(months) || isempty(shortmonths)
-        shortmonths = [length(m) >= 3 ? m[1:3] : m for m ∈ months]
+    if !isempty(months) && isempty(shortmonths)
+        shortmonths = first.(months, 3)
     end
     # set locale for this page
     Dates.LOCALES["date_locale"] = Dates.DateLocale(months, shortmonths, 

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -14,6 +14,10 @@ const GLOBAL_VARS_DEFAULT = [
     # General
     "author"           => Pair("THE AUTHOR",   (String, Nothing)),
     "date_format"      => Pair("U dd, yyyy",   (String,)),
+    "date_months"      => Pair(String[],       (Vector{String},)),
+    "date_shortmonths" => Pair(String[],       (Vector{String},)),
+    "date_days"        => Pair(String[],       (Vector{String},)),
+    "date_shortdays"   => Pair(String[],       (Vector{String},)),
     "prepath"          => Pair("",             (String,)),
     # will be added to IGNORE_FILES
     "ignore"           => Pair(String[],       (Vector{String},)),
@@ -181,9 +185,37 @@ Convenience functions related to the page vars
 
 """
 Convenience function taking a `DateTime` object and returning the corresponding
-formatted string with the format contained in `LOCAL_VARS["date_format"]`.
+formatted string with the format contained in `LOCAL_VARS["date_format"]` and 
+with the locale data provided in `date_months`, `date_shortmonths`, `date_days`, 
+and `date_shortdays` local variables. If `short` variations are not provided,
+automatically construct them using the first three letters of the names in
+`date_months` and `date_days`.
 """
-fd_date(d::DateTime) = Dates.format(d, LOCAL_VARS["date_format"].first)
+function fd_date(d::DateTime)
+    # aliases for locale data and format from local variables
+    format      = LOCAL_VARS["date_format"].first
+    months      = LOCAL_VARS["date_months"].first
+    shortmonths = LOCAL_VARS["date_shortmonths"].first
+    days        = LOCAL_VARS["date_days"].first
+    shortdays   = LOCAL_VARS["date_shortdays"].first
+    # if vectors are empty, user has not defined custom locale,
+    # defaults to english
+    if all(isempty.((months, shortmonths, days, shortdays)))
+        return Dates.format(d, format, locale="english")
+    end
+    # if shortdays or shortmonths are undefined,
+    # automatically construct them from other lists
+    if !isempty(days) || isempty(shortdays)
+        shortdays = [length(d) >= 3 ? d[1:3] : d for d ∈ days]
+    end
+    if !isempty(months) || isempty(shortmonths)
+        shortmonths = [length(m) >= 3 ? m[1:3] : m for m ∈ months]
+    end
+    # set locale for this page
+    Dates.LOCALES["date_locale"] = Dates.DateLocale(months, shortmonths, 
+                                                    days, shortdays)
+    return Dates.format(d, format, locale="date_locale")
+end
 
 
 """

--- a/test/utils/misc.jl
+++ b/test/utils/misc.jl
@@ -125,3 +125,86 @@ end
     @test F.check_type(Vector{String},  (Vector{Any},))
     @test !F.check_type(Vector{String}, (Matrix{Any},))
 end
+
+@testset "Date locales" begin
+    s = raw"""
+    @def date_format = "e, d u Y"
+    @def date_months = ["janvier", "février", "mars", "avril", "mai", "juin",
+                        "juillet", "août", "septembre", "octobre", "novembre", 
+                        "décembre"];
+    @def date_shortmonths = ["janv","févr","mars","avril","mai","juin",
+                                "juil","août","sept","oct","nov","déc"];
+    @def date_days = ["lundi","mardi","mercredi","jeudi",
+                        "vendredi","samedi","dimanche"];
+    ```julia:ex
+    #hideall
+    using Franklin, Dates
+    println(Franklin.fd_date(DateTime("1996-01-01T12:30:00")))
+    ```
+    \textoutput{ex}
+    """ |> fd2html_td
+    @test isapproxstr(s, "lun, 1 janv 1996") # auto short names
+
+    s = raw"""
+    @def date_format = "d u Y"
+    @def date_months = ["janvier", "février", "mars", "avril", "mai", "juin",
+                        "juillet", "août", "septembre", "octobre", "novembre", 
+                        "décembre"];
+    ```julia:ex
+    #hideall
+    using Franklin, Dates
+    println(Franklin.fd_date(DateTime("1996-12-01T12:30:00")))
+    ```
+    \textoutput{ex}
+    """ |> fd2html_td
+    println(s)
+    @test isapproxstr(s, "1 déc 1996") # accents in short names
+
+    s = raw"""
+    @def date_format = "d u Y"
+    @def date_shortmonths = ["janv","févr","mars","avril","mai","juin",
+                                "juil","août","sept","oct","nov","déc"];
+    ```julia:ex
+    #hideall
+    using Franklin, Dates
+    println(Franklin.fd_date(DateTime("1996-01-01T12:30:00")))
+    ```
+    \textoutput{ex}
+    """ |> fd2html_td
+    @test isapproxstr(s, "1 janv 1996") # only short names defined
+
+    s = raw"""
+    @def date_format = "Y年ud日　E"
+    @def date_months = ["1月", "2月", "3月", "4月", "5月", "6月",
+                        "7月", "8月", "9月", "10月", "11月", "12月"];
+
+    @def date_days = ["月曜日","火曜日","水曜日","木曜日",
+                        "金曜日","土曜日","日曜日"];
+    ```julia:ex
+    #hideall
+    using Franklin, Dates
+    println(Franklin.fd_date(DateTime("1996-01-01T12:30:00")))
+    ```
+    \textoutput{ex}
+    """ |> fd2html_td
+    println(s) # french result????
+    @test isapproxstr(s, "1996年1月1日　月曜日") # japanese and unicode
+
+    s = raw"""
+    @def date_format = "Y年ud日　E"
+    @def date_months = ["1月", "2月", "3月", "4月", "5月", "6月",
+                        "7月", "8月", "9月", "10月", "11月", "12月"];
+
+    @def date_days = ["月曜日","火曜日","水曜日","木曜日",
+                        "金曜日","土曜日","日曜日"];
+    ```julia:ex
+    #hideall
+    using Franklin, Dates
+    println(Franklin.fd_date(DateTime("1996-12-01T12:30:00")))
+    ```
+    \textoutput{ex}
+    """ |> fd2html_td
+    println(s) # if I change the date now it's proper japanese?
+    @test isapproxstr(s, "1996年12月1日　日曜日") # japanese and unicode
+
+end

--- a/test/utils/misc.jl
+++ b/test/utils/misc.jl
@@ -136,12 +136,12 @@ end
                                 "juil","août","sept","oct","nov","déc"];
     @def date_days = ["lundi","mardi","mercredi","jeudi",
                         "vendredi","samedi","dimanche"];
-    ```julia:ex
+    ```julia:ex1
     #hideall
     using Franklin, Dates
     println(Franklin.fd_date(DateTime("1996-01-01T12:30:00")))
     ```
-    \textoutput{ex}
+    \textoutput{ex1}
     """ |> fd2html_td
     @test isapproxstr(s, "lun, 1 janv 1996") # auto short names
 
@@ -150,26 +150,25 @@ end
     @def date_months = ["janvier", "février", "mars", "avril", "mai", "juin",
                         "juillet", "août", "septembre", "octobre", "novembre", 
                         "décembre"];
-    ```julia:ex
+    ```julia:ex2
     #hideall
     using Franklin, Dates
     println(Franklin.fd_date(DateTime("1996-12-01T12:30:00")))
     ```
-    \textoutput{ex}
+    \textoutput{ex2}
     """ |> fd2html_td
-    println(s)
     @test isapproxstr(s, "1 déc 1996") # accents in short names
 
     s = raw"""
     @def date_format = "d u Y"
     @def date_shortmonths = ["janv","févr","mars","avril","mai","juin",
                                 "juil","août","sept","oct","nov","déc"];
-    ```julia:ex
+    ```julia:ex3
     #hideall
     using Franklin, Dates
     println(Franklin.fd_date(DateTime("1996-01-01T12:30:00")))
     ```
-    \textoutput{ex}
+    \textoutput{ex3}
     """ |> fd2html_td
     @test isapproxstr(s, "1 janv 1996") # only short names defined
 
@@ -180,31 +179,12 @@ end
 
     @def date_days = ["月曜日","火曜日","水曜日","木曜日",
                         "金曜日","土曜日","日曜日"];
-    ```julia:ex
+    ```julia:ex4
     #hideall
     using Franklin, Dates
     println(Franklin.fd_date(DateTime("1996-01-01T12:30:00")))
     ```
-    \textoutput{ex}
+    \textoutput{ex4}
     """ |> fd2html_td
-    println(s) # french result????
     @test isapproxstr(s, "1996年1月1日　月曜日") # japanese and unicode
-
-    s = raw"""
-    @def date_format = "Y年ud日　E"
-    @def date_months = ["1月", "2月", "3月", "4月", "5月", "6月",
-                        "7月", "8月", "9月", "10月", "11月", "12月"];
-
-    @def date_days = ["月曜日","火曜日","水曜日","木曜日",
-                        "金曜日","土曜日","日曜日"];
-    ```julia:ex
-    #hideall
-    using Franklin, Dates
-    println(Franklin.fd_date(DateTime("1996-12-01T12:30:00")))
-    ```
-    \textoutput{ex}
-    """ |> fd2html_td
-    println(s) # if I change the date now it's proper japanese?
-    @test isapproxstr(s, "1996年12月1日　日曜日") # japanese and unicode
-
 end


### PR DESCRIPTION
This is a workaround I made for my site so I can define custom names for the months of the year and days of the week, and their abbreviations. As I am using the `locale` functionality of `Dates`, I'll be calling it "locale" customization.

The usage is simple, and like `date_format`, the user can set some local/global variables:
 - `date_days` : list with the names for days of the week
 - `date_shortdays` : list with the abbreviated names for the days of the week
 - `date_months` : list with the names of months
 - `date_shortmonths` : list with the abbreviated names of months

If any of the `short` variations are not set, the `fd_date` function tries to automatically create those by using the first three characters of the names of months or days of week.

Maybe this is not the right way to implement it, but as I have done it anyway, I present this as my first contribution :upside_down_face: I also don't know the proper way to add tests to this, should it be like the `cond-insert` tests?