### PR TITLE
I432

### DIFF
--- a/src/converter/markdown/blocks.jl
+++ b/src/converter/markdown/blocks.jl
@@ -23,6 +23,7 @@ function convert_block(β::AbstractBlock, lxdefs::Vector{LxDef})::AS
     βn == :LINK_DEF        && return ""
 
     βn == :DOUBLE_BRACE    && return β.ss # let HTML converter deal with it
+    βn == :HORIZONTAL_RULE && return "<hr />"
 
     # Math block --> needs to call further processing to resolve possible latex
     βn ∈ MATH_BLOCKS_NAMES && return convert_math_block(β, lxdefs)

--- a/src/converter/markdown/md.jl
+++ b/src/converter/markdown/md.jl
@@ -43,6 +43,8 @@ function convert_md(mds::AS,
     validate_footnotes!(tokens)
     # ignore header tokens that are not at the start of a line
     validate_headers!(tokens)
+    # capture some hrule (see issue #432)
+    validate_hrule!(tokens)
     #> 1b. Find indented blocks (ONLY if not recursive to avoid ambiguities!)
     if !isrecursive
         find_indented_blocks!(tokens, mds)
@@ -89,7 +91,8 @@ function convert_md(mds::AS,
 
     #> 3[ex]. find double brace blocks, note we do it on pre_ocb tokens
     # as the step `find_all_ocblocks` possibly found and deactivated {...}.
-    dbb = find_double_brace_blocks(toks_pre_ocb)
+    dbb     = find_double_brace_blocks(toks_pre_ocb)
+    hrules  = filter(τ -> τ.name == :HORIZONTAL_RULE, tokens)
 
     # ------------------------------------------------------------------------
     #> 4. Page variable definition (mddefs), also if in config, update lxdefs
@@ -116,12 +119,12 @@ function convert_md(mds::AS,
     #
     # filter out the fnrefs that are left (still active)
     # and add them to the blocks to insert
-    fnrefs = filter!(τ -> τ.name == :FOOTNOTE_REF, tokens)
+    fnrefs = filter(τ -> τ.name == :FOOTNOTE_REF, tokens)
 
     #> 1. Merge all the blocks that will need further processing before
     # insertion
     b2insert = merge_blocks(lxcoms, deactivate_divs(blocks),
-                            sp_chars, fnrefs, dbb)
+                            sp_chars, fnrefs, dbb, hrules)
 
     #> 2. Form intermediate markdown + html
     inter_md, mblocks = form_inter_md(mds, b2insert, lxdefs)

--- a/src/parser/markdown/tokens.jl
+++ b/src/parser/markdown/tokens.jl
@@ -30,13 +30,14 @@ possibilities to consider in which case the order is important: the first case
 that works will be taken.
 """
 const MD_TOKENS = LittleDict{Char, Vector{TokenFinder}}(
-    '<'  => [ isexactly("<!--") => :COMMENT_OPEN,     # <!-- ...
+    '<'  => [ isexactly("<!--")  => :COMMENT_OPEN,     # <!-- ...
              ],
-    '-'  => [ isexactly("-->")  => :COMMENT_CLOSE,    #      ... -->
+    '-'  => [ isexactly("-->")   => :COMMENT_CLOSE,    #  ... -->
+              incrlook(is_hrule) => :HORIZONTAL_RULE,  # ---+
              ],
-    '~'  => [ isexactly("~~~")  => :ESCAPE,           # ~~~  ... ~~~
+    '~'  => [ isexactly("~~~")   => :ESCAPE,           # ~~~  ... ~~~
              ],
-    '['  => [ incrlook(is_footnote) => :FOOTNOTE_REF,    # [^...](:)? defs will be separated after
+    '['  => [ incrlook(is_footnote) => :FOOTNOTE_REF, # [^...](:)? defs will be separated after
              ],
     ']'  => [ isexactly("]: ") => :LINK_DEF,
              ],
@@ -77,10 +78,11 @@ const MD_TOKENS = LittleDict{Char, Vector{TokenFinder}}(
     '&'  => [ incrlook(is_html_entity) => :CHAR_HTML_ENTITY,
              ],
     '$'  => [ isexactly("\$", ('$',), false) => :MATH_A,  # $⎵*
-              isexactly("\$\$") => :MATH_B,              # $$⎵*
+              isexactly("\$\$")              => :MATH_B,  # $$⎵*
              ],
-    '_'  => [ isexactly("_\$>_") => :MATH_I_OPEN,   # internal use when resolving a latex command
-              isexactly("_\$<_") => :MATH_I_CLOSE,  # within mathenv (e.g. \R <> \mathbb R)
+    '_'  => [ isexactly("_\$>_") => :MATH_I_OPEN,  # internal use when resolving a latex command
+              isexactly("_\$<_") => :MATH_I_CLOSE, # within mathenv (e.g. \R <> \mathbb R)
+              incrlook(is_hrule) => :HORIZONTAL_RULE,
              ],
     '`'  => [ isexactly("`", ('`',), false)  => :CODE_SINGLE, # `⎵
               isexactly("``",('`',), false)  => :CODE_DOUBLE, # ``⎵*
@@ -89,6 +91,8 @@ const MD_TOKENS = LittleDict{Char, Vector{TokenFinder}}(
               is_language()                  => :CODE_LANG,   # ```lang*
               is_language2()                 => :CODE_LANG2,  # `````lang*
              ],
+    '*'  => [ incrlook(is_hrule) => :HORIZONTAL_RULE,
+             ]
     ) # end dict
 #= NOTE
 [1] capturing \{ here will force the head to move after it thereby not

--- a/src/parser/markdown/tokens.jl
+++ b/src/parser/markdown/tokens.jl
@@ -41,12 +41,12 @@ const MD_TOKENS = LittleDict{Char, Vector{TokenFinder}}(
     ']'  => [ isexactly("]: ") => :LINK_DEF,
              ],
     '\\' => [ # -- special characters, see `find_special_chars` in ocblocks
-              isexactly("\\\\")       => :CHAR_LINEBREAK, # --> <br/>
-              isexactly("\\", (' ',)) => :CHAR_BACKSPACE, # --> &#92;
-              isexactly("\\*")        => :CHAR_ASTERISK,  # --> &#42;
-              isexactly("\\_")        => :CHAR_UNDERSCORE,# --> &#95;
-              isexactly("\\`")        => :CHAR_BACKTICK,  # --> &#96;
-              isexactly("\\@")        => :CHAR_ATSIGN,    # --> &#64;
+              isexactly("\\\\")       => :CHAR_LINEBREAK,   # --> <br/>
+              isexactly("\\", (' ',)) => :CHAR_BACKSPACE,   # --> &#92;
+              isexactly("\\*")        => :CHAR_ASTERISK,    # --> &#42;
+              isexactly("\\_")        => :CHAR_UNDERSCORE,  # --> &#95;
+              isexactly("\\`")        => :CHAR_BACKTICK,    # --> &#96;
+              isexactly("\\@")        => :CHAR_ATSIGN,      # --> &#64;
               # -- maths
               isexactly("\\{")        => :INACTIVE,         # See note [^1]
               isexactly("\\}")        => :INACTIVE,         # See note [^1]
@@ -61,11 +61,11 @@ const MD_TOKENS = LittleDict{Char, Vector{TokenFinder}}(
               isexactly("\\end{eqnarray}")   => :MATH_EQA_CLOSE,
               # -- latex
               isexactly("\\newcommand")      => :LX_NEWCOMMAND,
-              incrlook((_, c) -> α(c))       => :LX_COMMAND,     # \command⎵*
+              incrlook((_, c) -> α(c))       => :LX_COMMAND,  # \command⎵*
              ],
-    '@'  => [ isexactly("@def", (' ',))   => :MD_DEF_OPEN,  # @def var = ...
-              isexactly("@@", SPACE_CHAR) => :DIV_CLOSE,    # @@⎵*
-              incrlook(is_div_open)       => :DIV_OPEN,     # @@dname
+    '@'  => [ isexactly("@def", (' ',))   => :MD_DEF_OPEN,    # @def var = ...
+              isexactly("@@", SPACE_CHAR) => :DIV_CLOSE,      # @@⎵*
+              incrlook(is_div_open)       => :DIV_OPEN,       # @@dname
              ],
     '#'  => [ isexactly("#",      (' ',)) => :H1_OPEN, # see note [^2]
               isexactly("##",     (' ',)) => :H2_OPEN,

--- a/src/parser/markdown/validate.jl
+++ b/src/parser/markdown/validate.jl
@@ -33,7 +33,7 @@ $SIGNATURES
 Verify that a given string corresponds to a well formed html entity.
 """
 function validate_html_entity(ss::AS)
-    !isnothing(match(r"&(?:[a-z0-9]+|#[0-9]{1,6}|#x[0-9a-f]{1,6});", ss))
+    !isnothing(match(HTML_ENT_PAT, ss))
 end
 
 """
@@ -59,7 +59,6 @@ function validate_headers!(tokens::Vector{Token})::Nothing
     deleteat!(tokens, rm)
     return
 end
-
 
 """
 $(SIGNATURES)
@@ -173,4 +172,33 @@ function find_double_brace_blocks(tokens)
         head += 1
     end
     return dbb
+end
+
+"""
+$SIGNATURES
+
+Check that a `---` or `***` or `___` starts at the beginning of a line and is preceded by an empty line, if that's not the case, discard it.
+"""
+function validate_hrule!(tokens::Vector{Token})
+    rm = Int[]
+    for (i, τ) in enumerate(tokens)
+        τ.name == :HORIZONTAL_RULE || continue
+        # check if it has the right format
+        if !(startswith(τ.ss, "---") ||
+             startswith(τ.ss, "___") ||
+             startswith(τ.ss, "***")) || length(unique(τ.ss)) > 1
+            push!(rm, i)
+            continue
+        end
+        # check if it's at the start of the string  or
+        # if it's preceded by an empty line, in which case mark it as
+        # horizontal rule, leave all other cases to be dealt with by Julia's
+        # Markdown parser.
+        s, k = str(τ), from(τ)
+        if !(k == 1 || s[prevind(s, k, 2):prevind(s, k)] == "\n\n")
+            push!(rm, i)
+        end
+    end
+    deleteat!(tokens, rm)
+    return nothing
 end

--- a/src/parser/tokens.jl
+++ b/src/parser/tokens.jl
@@ -50,6 +50,7 @@ end
 HTML_SPCH(ss) = HTML_SPCH(ss, "")
 
 
+
 """
 $(TYPEDEF)
 
@@ -282,6 +283,15 @@ function is_footnote(i::Int, c::Char)
     i == 1 && return c == '^'
     i == 2 && return αη(c)
     i > 2  && return αη(c, (']', ':'))
+end
+
+"""
+$SIGNATURES
+
+Check if it looks like `[-_*]{3}+`.
+"""
+function is_hrule(::Int, c::Char)
+    return c in ('_', '-', '*')
 end
 
 """

--- a/src/regexes.jl
+++ b/src/regexes.jl
@@ -51,6 +51,11 @@ const ESC_LINK_PAT = r"(&#33;)?&#91;(.*?)&#93;(?!:)(?:&#91;(.*?)&#93;)?"
 const FN_DEF_PAT = r"^\[\^[\p{L}0-9_]+\](:)?$"
 
 #= =====================================================
+HTML entity pattern
+===================================================== =#
+const HTML_ENT_PAT = r"&(?:[a-z0-9]+|#[0-9]{1,6}|#x[0-9a-f]{1,6});"
+
+#= =====================================================
 HBLOCK patterns, see html blocks
 NOTE: the &#123 is { and 125 is }, this is because
 Markdown.html converts { => html entity but we want to

--- a/test/parser/markdown-extra.jl
+++ b/test/parser/markdown-extra.jl
@@ -136,3 +136,45 @@ end
     @test isapproxstr(s, """
         hello \\(\\rho=\\frac{e^{-\\beta \\mathcal{E}_{s}}} {\\mathcal{Z}} \\)""")
 end
+
+# issue 432 and consequences
+@testset "Hz rule" begin
+    # issue 432
+    s = raw"""
+        hello[^a]
+
+        [^a]: world
+
+        ---
+        """ |> fd2html_td
+    @test isapproxstr(s, """
+        <p>hello<sup id="fnref:a"><a href="#fndef:a" class="fnref">[1]</a></sup>
+        <table class="fndef" id="fndef:a">
+            <tr>
+                <td class="fndef-backref"><a href="#fnref:a">[1]</a></td>
+                <td class="fndef-content">world</td>
+            </tr>
+        </table>
+        <hr /></p>
+        """)
+    s = raw"""
+        A
+        ---
+        """ |> fd2html_td
+    @test isapproxstr(s, """
+        <h2>A</h2>""")
+    s = raw"""
+        A
+        ----
+        ****
+        """ |> fd2html_td
+    @test isapproxstr(s, "<h2>A</h2>\n<hr />")
+
+    # cases where nothing should happen
+    s = raw"""
+        A
+        ---*
+        ***_
+        """ |> fd2html_td
+    @test isapproxstr(s, "<p>A –-* ***_</p>") # note double -- is transformed -
+end

--- a/test/regexes.jl
+++ b/test/regexes.jl
@@ -71,6 +71,26 @@ end
     end
 end
 
+### HTML ENTITY
+@testset "html-ent" begin
+    for s in (
+        "&tab;",
+     	"&newline;",
+        "&excl;",
+        "&quot;",
+        "&#x00009;",
+        "&#x00027;",
+        "&#39;",
+        "&#58;",
+        "&#123;",
+        "&ccirc;",
+        "&#x00107;",
+        "&#263;"
+        )
+        @test !isnothing(match(F.HTML_ENT_PAT, s))
+    end
+end
+
 ### HBLOCK REGEXES
 
 @testset "hb-if" begin


### PR DESCRIPTION
closes #432 

It was a bit trickier than I thought, anyway I took the lazy route, so now if Franklin sees `---` or `***` or `___` (or more than 3) at the beginning of a new line after an empty line (so for instance `\n\n---` it will  capture it and force introduce  `<hr />`, the rest of the time it defers to Julia's markdown parser so that

```
A
---
```

is effectively  parsed as `<h2>A</h2>`.

The commit is larger than it seems but that's because I added some more tests for regexes, those can safely be ignored.