### PR TITLE
Closes #439

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.6.16"
+version = "0.6.17"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/converter/markdown/md.jl
+++ b/src/converter/markdown/md.jl
@@ -200,7 +200,7 @@ function convert_md_math(ms::AS, lxdefs::Vector{LxDef}=Vector{LxDef}(),
         next_lxc = from_ifsmaller(lxcoms, lxc_idx, len_lxc)
     end
     # add anything after the last command
-    (head ≤ strlen) && write(htmls, chop(ms, head=prevind(ms, head), tail=0))
+    (head <= strlen) && write(htmls, subs(ms, head, strlen))
     return String(take!(htmls))
 end
 

--- a/test/parser/markdown-extra.jl
+++ b/test/parser/markdown-extra.jl
@@ -178,3 +178,12 @@ end
         """ |> fd2html_td
     @test isapproxstr(s, "<p>A –-* ***_</p>") # note double -- is transformed -
 end
+
+# issue 439 and consequences
+@testset "mathunicode" begin
+    s = raw"""
+        \newcommand{\u}{1}
+        $$ φφφ\u abcdef $$
+        """ |> fd2html_td
+    @test isapproxstr(s, raw"\[ φφφ1 abcdef \]")
+end


### PR DESCRIPTION
Fixes `convert_md_math` where the end of the string in a math environment was written to the buffer in a way that was prone to problems in case there were unicode characters in that string.