### PR TITLE
#444 and #447

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ julia> serve()
 Modify the files in `MyNewSite/src` and see the changes being live-rendered in your browser.
 Head to [the docs](https://franklinjl.org) for more information.
 
+### Heads up!
+
+While Franklin broadly supports standard Markdown there are a few things that may trip you which are either due to Franklin or due to Julia's Markdown library, here are key ones you should keep in mind:
+
+* when writing a list, the content of the list item **must** be on a single line (no line break)
+* (as of `v0.6.15`) you can write comments with `<!-- comments -->` the comment markers `<!--` and `-->` **must** be separated by a character that is not a `-` to work properly so `<!--A-->` is ok but `<!---A--->` is not, best is to just systematically use a whitespace: `<!-- A -->`.
+* (as of `v0.7`) code blocks should be delimited with backticks `` ` `` you *can* also use indented blocks to delimit code blocks but you now have to **opt in** explicitly on pages that would use them by using `@def indented_code = true`, if you want to use that everywhere, write that in the `config.md`. Note that indented blocks are **ambiguous** with some of the other things that Franklin provides (div blocks, latex commands) and so if you use them, you are responsible for avoiding ambiguities (effectively that means _not using indentation for anything else than code_)
+
+
+
 ## Associated repositories
 
 * [LiveServer.jl](https://github.com/asprionj/LiveServer.jl) a package coded with [Jonas Asprion](https://github.com/asprionj) to render and watch the content of a local folder in the browser.

--- a/src/converter/markdown/md.jl
+++ b/src/converter/markdown/md.jl
@@ -68,6 +68,7 @@ function convert_md(mds::AS,
     #>> a'. find the rest
     blocks2, tokens = find_all_ocblocks(tokens, vcat(MD_OCB2, MD_OCB_MATH))
     append!(blocks, blocks2)
+    deactivate_inner_blocks!(blocks)
     #>> b. merge CODE_BLOCK_IND which are separated by emptyness
     merge_indented_blocks!(blocks, mds)
     #>> b'. only keep indented code blocks which are not contained in larger
@@ -91,7 +92,7 @@ function convert_md(mds::AS,
 
     #> 3[ex]. find double brace blocks, note we do it on pre_ocb tokens
     # as the step `find_all_ocblocks` possibly found and deactivated {...}.
-    dbb     = find_double_brace_blocks(toks_pre_ocb)
+    dbb = find_double_brace_blocks(toks_pre_ocb)
 
     # ------------------------------------------------------------------------
     #> 4. Page variable definition (mddefs), also if in config, update lxdefs

--- a/src/parser/markdown/tokens.jl
+++ b/src/parser/markdown/tokens.jl
@@ -242,7 +242,8 @@ const MATH_BLOCKS_NAMES = [e.name for e ∈ MD_OCB_MATH]
 """
 MD_OCB_NO_INNER
 
-List of names of blocks which will deactivate any block contained within them.
+List of names of blocks which will deactivate any block contained within them
+as their content will be reprocessed later on.
 See [`find_all_ocblocks`](@ref).
 """
-const MD_OCB_NO_INNER = vcat(MD_OCB_ESC, MATH_BLOCKS_NAMES, :LXB)
+const MD_OCB_NO_INNER = vcat(MD_OCB_ESC, MATH_BLOCKS_NAMES, :LXB, MD_HEADER)

--- a/test/converter/markdown3.jl
+++ b/test/converter/markdown3.jl
@@ -101,9 +101,9 @@ end
     steps = explore_md_steps(st)
     blocks, tokens = steps[:ocblocks]
     @test blocks[1].name == :CODE_INLINE
-    @test F.content(blocks[1]) == "double ` double"
+    @test F.content(blocks[1]) == "single"
+    @test F.content(blocks[2]) == "double ` double"
     @test blocks[2].name == :CODE_INLINE
-    @test F.content(blocks[2]) == "single"
 
     st = raw"""A `single` and ``double ` double`` and ``` triple ``` B"""
     steps = explore_md_steps(st)
@@ -116,23 +116,23 @@ end
     @test tokens[6].name == :CODE_TRIPLE
     @test tokens[7].name == :CODE_TRIPLE
     blocks, tokens = steps[:ocblocks]
-    @test blocks[1].name == :CODE_BLOCK
-    @test F.content(blocks[1]) == " triple "
+    @test blocks[3].name == :CODE_BLOCK
+    @test F.content(blocks[3]) == " triple "
     @test blocks[2].name == :CODE_INLINE
-    @test blocks[3].name == :CODE_INLINE
+    @test blocks[1].name == :CODE_INLINE
 
     st = raw"""A `single` and ``double ` double`` and ``` triple `` triple```
                and ```julia 1+1``` and `single again` done"""
     steps = explore_md_steps(st)
     blocks, _ = steps[:ocblocks]
-    @test blocks[1].name == :CODE_BLOCK_LANG
-    @test F.content(blocks[1]) == " 1+1"
-    @test blocks[2].name == :CODE_BLOCK
-    @test F.content(blocks[2]) == " triple `` triple"
-    @test blocks[3].name == :CODE_INLINE
-    @test F.content(blocks[3]) == "double ` double"
-    @test blocks[4].name == :CODE_INLINE
-    @test F.content(blocks[4]) == "single"
+    @test blocks[4].name == :CODE_BLOCK_LANG
+    @test F.content(blocks[4]) == " 1+1"
+    @test blocks[3].name == :CODE_BLOCK
+    @test F.content(blocks[3]) == " triple `` triple"
+    @test blocks[2].name == :CODE_INLINE
+    @test F.content(blocks[2]) == "double ` double"
+    @test blocks[1].name == :CODE_INLINE
+    @test F.content(blocks[1]) == "single"
 end
 
 @testset "\\ and \`" begin # see issue 203

--- a/test/global/ordering.jl
+++ b/test/global/ordering.jl
@@ -60,8 +60,8 @@ end
     steps = st |> explore_md_steps
     blocks, = steps[:ocblocks]
     @test length(blocks) == 2
-    @test blocks[1].name == :COMMENT
-    @test blocks[2].name == :MATH_EQA
+    @test blocks[1].name == :MATH_EQA
+    @test blocks[2].name == :COMMENT
 
     @test isapproxstr(st |> seval, raw"""
             <p>A

--- a/test/parser/latex++.jl
+++ b/test/parser/latex++.jl
@@ -1,0 +1,22 @@
+# Let's test latex commands to death... especially in light of #444
+
+@testset "lx++1" begin
+    # 444
+    s = "\\newcommand{\\note}[1]{#1} \\note{A `B` C} D" |> fd2html_td
+    @test isapproxstr(s, """
+        A <code>B</code> C D
+        """)
+    s = raw"""
+        \newcommand{\note}[1]{@@note #1 @@}
+        \note{A}
+        \note{A `B` C}
+        \note{A @@cc B @@ D}
+        \note{A @@cc B `D` E @@ F}
+        """ |> fd2html_td
+    @test isapproxstr(s, """
+        <div class="note">A</div>
+        <div class="note">A <code>B</code> C</div>
+        <div class="note">A <div class="cc">B</div> D</div>
+        <div class="note">A <div class="cc">B <code>D</code> E</div> F</div>
+        """)
+end

--- a/test/parser/markdown+latex.jl
+++ b/test/parser/markdown+latex.jl
@@ -24,27 +24,26 @@ end
 
     steps = explore_md_steps(st)
     blocks, tokens = steps[:ocblocks]
-    braces = filter(β -> β.name == :LXB, blocks)
-
-    # escape block
-    β = blocks[2]
-    @test β.name == :ESCAPE
-    @test β.ss == "~~~\nescape block\n~~~"
 
     # inline code block
     β = blocks[1]
     @test β.name == :CODE_INLINE
     @test β.ss == "`code`"
 
-    # brace block
-    β = braces[1]
-    @test β.name == :LXB
-    @test β.ss == "{target}"
-
     # div block
-    β = blocks[4]
+    β = blocks[2]
     @test β.name == :DIV
     @test β.ss == "@@dname block @@"
+
+    # escape block
+    β = blocks[3]
+    @test β.name == :ESCAPE
+    @test β.ss == "~~~\nescape block\n~~~"
+
+    # escape block
+    β = blocks[4]
+    @test β.name == :LXB
+    @test β.ss == "{target}"
 end
 
 
@@ -96,8 +95,8 @@ end
     @test lxdefs[3].narg == 0
     @test lxdefs[3].def  == "\\mathbb R"
 
-    @test blocks[2].name == :ESCAPE
-    @test blocks[1].name == :CODE_BLOCK_LANG
+    @test blocks[1].name == :ESCAPE
+    @test blocks[2].name == :CODE_BLOCK_LANG
 
     lxcoms, tokens = F.find_lxcoms(tokens, lxdefs, braces)
 
@@ -215,12 +214,12 @@ end
 
     lxdefs, tokens, braces, blocks, lxcoms = explore_md_steps(st)[:latex]
 
-    @test blocks[1].name == :COMMENT
-    @test F.content(blocks[1]) == " comment "
+    @test blocks[1].name == :MD_DEF
+    @test F.content(blocks[1]) == " title = \"Convex Optimisation I\""
+    @test blocks[2].name == :COMMENT
+    @test F.content(blocks[2]) == " comment "
     @test blocks[3].name == :H2
     @test F.content(blocks[3]) == " blah <!-- ✅ 19/9/999 -->"
-    @test blocks[2].name == :MD_DEF
-    @test F.content(blocks[2]) == " title = \"Convex Optimisation I\""
 
     @test lxcoms[1].ss == "\\com{A}"
     @test lxcoms[2].ss == "\\com{B}"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ include("parser/2-blocks.jl")
 include("parser/markdown+latex.jl")
 include("parser/markdown-extra.jl")
 include("parser/footnotes+links.jl")
+include("parser/latex++.jl")
 println("🍺")
 
 # EVAL


### PR DESCRIPTION
Non breaking patch 

### 444

See the comment in https://github.com/tlienart/Franklin.jl/issues/444#issuecomment-611937199, the PR essentially adds `deactivate_inner_blocks!` which does the work that used to be done when finding ocblocks. It's refactored a bit and tested more.

Auxiliary changes to tests to adjust to this (basically now blocks are sorted so that changed a few things in the tests)

### 447

adds a paragraph in the readme

Closes #444 closes #447 