### PR TITLE
closes #419

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/converter/markdown/mddefs.jl
+++ b/src/converter/markdown/mddefs.jl
@@ -33,6 +33,26 @@ function process_mddefs(blocks::Vector{OCBlock}, isconfig::Bool)::Nothing
         set_vars!(GLOBAL_VARS, assignments)
     else
         set_vars!(LOCAL_VARS, assignments)
+
+        # is hascode or hasmath set explicitly? if not and if the global
+        # autocode and/or automath are left to true, then check here to see
+        # if there are any blocks and set the variable automatically (#419)
+        acm = filter(p -> p.first in ("hascode", "hasmath"), assignments)
+        if globvar("autocode") &&
+                (isempty(acm) || !any(p -> p.first == "hascode", acm))
+            # check and set hascode automatically
+            code = any(b -> startswith(string(b.name), "CODE_BLOCK"), blocks)
+            set_var!(LOCAL_VARS, "hascode", code)
+        end
+        if globvar("automath") &&
+                (isempty(acm) || !any(p -> p.first == "hasmath", acm))
+            # check and set hasmath automatically
+            math = any(b -> b.name in MATH_BLOCKS_NAMES, blocks)
+            set_var!(LOCAL_VARS, "hasmath", math)
+        end
+
+        # copy the page vars to ALL_PAGE_VARS so that they can be accessed
+        # by other pages via `pagevar`.
         ALL_PAGE_VARS[splitext(locvar("fd_rpath"))[1]] = deepcopy(LOCAL_VARS)
     end
     return nothing

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -12,22 +12,25 @@ const GLOBAL_VARS_DEFAULT = [
     # Folder org
     "folder_structure" => Pair(FD_ENV[:STRUCTURE], (VersionNumber,)),
     # General
-    "author"           => Pair("THE AUTHOR",   (String, Nothing)),
-    "date_format"      => Pair("U dd, yyyy",   (String,)),
-    "date_months"      => Pair(String[],       (Vector{String},)),
-    "date_shortmonths" => Pair(String[],       (Vector{String},)),
-    "date_days"        => Pair(String[],       (Vector{String},)),
-    "date_shortdays"   => Pair(String[],       (Vector{String},)),
-    "prepath"          => Pair("",             (String,)),
+    "author"           => Pair("THE AUTHOR", (String, Nothing)),
+    "date_format"      => Pair("U dd, yyyy", (String,)),
+    "date_months"      => Pair(String[],     (Vector{String},)),
+    "date_shortmonths" => Pair(String[],     (Vector{String},)),
+    "date_days"        => Pair(String[],     (Vector{String},)),
+    "date_shortdays"   => Pair(String[],     (Vector{String},)),
+    "prepath"          => Pair("",           (String,)),
     # will be added to IGNORE_FILES
-    "ignore"           => Pair(String[],       (Vector{String},)),
+    "ignore"           => Pair(String[], (Vector{String},)),
     # RSS
-    "website_title"    => Pair("",             (String,)),
-    "website_descr"    => Pair("",             (String,)),
-    "website_url"      => Pair("",             (String,)),
-    "generate_rss"     => Pair(true,           (Bool,)),
+    "website_title"    => Pair("",   (String,)),
+    "website_descr"    => Pair("",   (String,)),
+    "website_url"      => Pair("",   (String,)),
+    "generate_rss"     => Pair(true, (Bool,)),
     # div names
-    "div_content"      => Pair("franklin-content", (String,))
+    "div_content"      => Pair("franklin-content", (String,)),
+    # auto detection of code / math (see hasmath/hascode)
+    "autocode"         => Pair(true, (Bool,)),
+    "automath"         => Pair(true, (Bool,)),
     ]
 
 """

--- a/test/global/cases2.jl
+++ b/test/global/cases2.jl
@@ -179,3 +179,21 @@ end
         </p>
         """)
 end
+
+@testset "i 419" begin
+    s = raw"""
+        {{hasmath}} {{hascode}}
+        $x = 5$
+        """ |> fdi
+    @test isapproxstr(s, "true false \\(x = 5\\)")
+    s = raw"""
+        {{hasmath}} {{hascode}}
+        ```r
+        blah
+        ```
+        """ |> fdi
+    @test isapproxstr(s, """
+        false true
+        <pre><code class=\"language-r\">blah</code></pre>
+        """)
+end

--- a/test/manager/utils.jl
+++ b/test/manager/utils.jl
@@ -1,7 +1,11 @@
 fs1()
 
 temp_config = joinpath(F.PATHS[:src], "config.md")
-write(temp_config, "@def author = \"Stefan Zweig\"\n")
+write(temp_config, raw"""
+    @def author = "Stefan Zweig"
+    @def automath = false
+    @def autocode = false
+    """)
 temp_index = joinpath(F.PATHS[:src], "index.md")
 write(temp_index, "blah blah")
 temp_index2 = joinpath(F.PATHS[:src], "index.html")

--- a/test/manager/utils_fs2.jl
+++ b/test/manager/utils_fs2.jl
@@ -1,7 +1,11 @@
 fs2()
 
 temp_config = joinpath(F.PATHS[:folder], "config.md")
-write(temp_config, "@def author = \"Stefan Zweig\"\n")
+write(temp_config, raw"""
+    @def author = "Stefan Zweig"
+    @def automath = false
+    @def autocode = false
+    """)
 temp_index = joinpath(F.PATHS[:folder], "index.md")
 write(temp_index, "blah blah")
 temp_index2 = joinpath(F.PATHS[:folder], "index.html")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -102,7 +102,6 @@ cd(dirname(dirname(pathof(Franklin))))
 
 println("TEMPLATING")
 include("templating/for.jl")
-# XXX XXX
 include("templating/fill.jl")
 
 println("UTILS FILE")

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -168,3 +168,5 @@ function fs2()
     mkdir(F.PATHS[:libs])
     mkdir(F.PATHS[:literate])
 end
+
+fdi(s) = fd2html(s; internal=true)

--- a/test/utils_file/basic.jl
+++ b/test/utils_file/basic.jl
@@ -5,7 +5,6 @@ write(joinpath("_layout", "head.html"), "")
 write(joinpath("_layout", "foot.html"), "")
 write(joinpath("_layout", "page_foot.html"), "")
 write("config.md", "")
-fdi(s) = fd2html(s; internal=true)
 
 @testset "utils1" begin
     write("utils.jl", """


### PR DESCRIPTION
Adds 

* global var `autocode` (default true)
* global var `automath` (default true)

if these are set to true **and** `hasmath` and/or `hascode` are **not** set on a page explicitly, then `hasmath` and `hascode` are set automatically based on whether there are code blocks / math blocks.

Basically for standard users, you can now stop writing `@def hascode = true` , `@def hasmath = true`, it's not necessary anymore.