### PR TITLE
WIP: tags

### DIFF
--- a/src/manager/franklin.jl
+++ b/src/manager/franklin.jl
@@ -106,6 +106,7 @@ function serve(; clear::Bool=false,
                       on_write=on_write)
     FD_ENV[:FORCE_REEVAL] = false
     sig < 0 && return sig
+    generate_tag_pages()
     fmsg = rpad("✔ full pass...", 40)
     verb && (println(""); print(fmsg); print_final(fmsg, start); println(""))
 

--- a/src/utils/misc.jl
+++ b/src/utils/misc.jl
@@ -232,3 +232,23 @@ function check_ping(ipaddr)
     opt = ifelse(Sys.iswindows(), "-n", "-c")
     return success(`ping $opt 1 -t 1 $ipaddr`)
 end
+
+"""
+    invert_dict(dict::Dict)
+
+Invert a dictionary i.e transform a=>[1,2],b=>[1] to 1=>[a,b], 2=>[a] 
+"""
+function invert_dict(dict::Dict)
+    dkeys = collect(keys(dict))
+    inv_dict = Dict{eltype(dict[dkeys[1]]), Vector{eltype(dict).types[1]}}()
+    for (key, val) in dict
+        for nkey in val
+            if haskey(inv_dict, nkey) 
+                push!(inv_dict[nkey], key)
+            else
+                inv_dict[nkey] = [key]
+            end
+        end
+    end
+    return inv_dict
+end

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -8,6 +8,10 @@ for that value. (e.g.: "THE AUTHOR" => (String, Nothing))
 """
 const GLOBAL_VARS = PageVars()
 
+# rpath => tags
+# UPPERCASE EVEN IF NOT CONST?
+TAGS = Dict{String, Vector{String}}()
+
 const GLOBAL_VARS_DEFAULT = [
     # Folder org
     "folder_structure" => Pair(FD_ENV[:STRUCTURE], (VersionNumber,)),
@@ -52,13 +56,14 @@ const LOCAL_VARS = PageVars()
 
 const LOCAL_VARS_DEFAULT = [
     # General
-    "title"         => Pair(nothing, (String, Nothing)),
-    "hasmath"       => Pair(true,    (Bool,)),
-    "hascode"       => Pair(false,   (Bool,)),
-    "date"          => Pair(Date(1), (String, Date, Nothing)),
-    "lang"          => Pair("julia", (String,)), # default lang indented code
-    "reflinks"      => Pair(true,    (Bool,)),   # are there reflinks?
-    "indented_code" => Pair(false,   (Bool,)),   # support indented code?
+    "title"         => Pair(nothing,    (String, Nothing)),
+    "hasmath"       => Pair(true,       (Bool,)),
+    "hascode"       => Pair(false,      (Bool,)),
+    "date"          => Pair(Date(1),    (String, Date, Nothing)),
+    "lang"          => Pair("julia",    (String,)), # default lang indented code
+    "reflinks"      => Pair(true,       (Bool,)),   # are there reflinks?
+    "indented_code" => Pair(false,      (Bool,)),   # support indented code?
+    "tags"          => Pair(String[],   (Vector{String},)),
     # -----------------
     # TABLE OF CONTENTS
     "mintoclevel" => Pair(1,  (Int,)), # set to 2 to ignore h1


### PR DESCRIPTION
Implementation of #456 
There sometimes is a bug that the initial pass fails because `path(:site)` fails not sure why.
State:
- `TAGS` holds information `rpath => [tag1, tag2]` which gets updated in each page:
`update_tags`
- Changes get passed to `generate_tag_pages` with the optional argument `tags` which holds all changed tags. In `generate_tag_pages` the tag pages are created/updated or if the tag doesn't exist anymore removed. 
- If `generate_tag_pages` is called without the argument it does this for all tags.

The functions are probably at the wrong places :wink:.
Currently the layout of the tags page is hard coded not sure how to use a layout file for this. 

Test cases:
Need some hints how to write test cases for actual checking whether the code works. Do you actually create a franklin site in the tests to check your functions? Or just some unit tests?