### PR TITLE
small fix for consistent automath

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.7.6"
+version = "0.7.7"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/converter/markdown/mddefs.jl
+++ b/src/converter/markdown/mddefs.jl
@@ -38,23 +38,19 @@ function process_mddefs(blocks::Vector{OCBlock}, isconfig::Bool,
     set_vars!(LOCAL_VARS, assignments)
     rpath = splitext(locvar("fd_rpath"))[1]
 
-    # is hascode or hasmath set explicitly? if not and if the global
-    # autocode and/or automath are left to true, then check here to see
-    # if there are any blocks and set the variable automatically (#419)
-    acm = filter(p -> p.first in ("hascode", "hasmath"), assignments)
-    if globvar("autocode") &&
-            (isempty(acm) || !any(p -> p.first == "hascode", acm))
+    hasmath = locvar(:hasmath)
+    hascode = locvar(:hascode)
+    if !hascode && globvar("autocode")
         # check and set hascode automatically
         code = any(b -> startswith(string(b.name), "CODE_BLOCK"), blocks)
         set_var!(LOCAL_VARS, "hascode", code)
     end
-    if globvar("automath") &&
-            (isempty(acm) || !any(p -> p.first == "hasmath", acm))
+    if !hasmath && globvar("automath")
         # check and set hasmath automatically
         math = any(b -> b.name in MATH_BLOCKS_NAMES, blocks)
         set_var!(LOCAL_VARS, "hasmath", math)
     end
-
+    
     # copy the page vars to ALL_PAGE_VARS so that they can be accessed
     # by other pages via `pagevar`.
     ALL_PAGE_VARS[rpath] = deepcopy(LOCAL_VARS)

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -59,7 +59,7 @@ const LOCAL_VARS = PageVars()
 const LOCAL_VARS_DEFAULT = [
     # General
     "title"         => Pair(nothing,    (String, Nothing)),
-    "hasmath"       => Pair(true,       (Bool,)),
+    "hasmath"       => Pair(false,      (Bool,)),
     "hascode"       => Pair(false,      (Bool,)),
     "date"          => Pair(Date(1),    (String, Date, Nothing)),
     "lang"          => Pair("julia",    (String,)), # default lang indented code

--- a/test/manager/utils.jl
+++ b/test/manager/utils.jl
@@ -59,7 +59,7 @@ end
     # testing write
     head = "head"
     pg_foot = "\npage_foot"
-    foot = "foot {{if hasmath}} {{fill author}}{{end}}"
+    foot = "foot {{fill author}}"
 
     out_file = F.form_output_path(F.PATHS[:folder], "index.html", :html)
     F.write_page(F.PATHS[:src], "index.md", head, pg_foot, foot, out_file)

--- a/test/manager/utils_fs2.jl
+++ b/test/manager/utils_fs2.jl
@@ -60,7 +60,7 @@ end
     # testing write
     head = "head"
     pg_foot = "\npage_foot"
-    foot = "foot {{if hasmath}} {{fill author}}{{end}}"
+    foot = "foot {{fill author}}"
 
     out_file = F.form_output_path(F.PATHS[:site], "index.html", :html)
     F.write_page(F.PATHS[:folder], "index.md", head, pg_foot, foot, out_file)


### PR DESCRIPTION
* Makes `hasmath`, `hascode` false by default
* if `hasmath` is false  and  if `automath` is true (default); then `hasmath` is checked  automatically depending on whether there actually are any math blocks (same for `hascode`) 

The previous behaviour was less consistent and could lead to  `hasmath = true` being ignored (happened  on JuliaLang website). 