### PR TITLE
minor fixes to pagevar

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.7.9"
+version = "0.7.10"
 
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -167,7 +167,12 @@ If `rpath` is not yet a key of `ALL_PAGE_VARS` then maybe the page hasn't been
 processed yet so force a pass over that page.
 """
 function pagevar(rpath::AS, name::Union{Symbol,String})
-    rpath = splitext(rpath)[1]
+    # only split extension if it's .md or .html (otherwise can cause trouble
+    # if there's a dot in the page name... not recommended but happens.)
+    rpc = splitext(rpath)[1]
+    if rpc[2] in (".md", ".html")
+        rpath = rpc[1]
+    end
 
     (:pagevar, "$rpath, $name (key: $(haskey(ALL_PAGE_VARS, rpath)))") |> logger
 


### PR DESCRIPTION
Fixes a  sneaky issue with `pagevar` if the page path was provided without extension but actually had  a `.` in its name. This was the case for a few of the Julialang blog posts which had things like `julia-0.4-release`; the problem is that `splitext` is blind about what would constitute an extension, so now this constrains the cases to be either `.md` or `.html`, otherwise no split.