### PR TITLE
WIP: basic way to ignore files with *

### DIFF
--- a/src/manager/dir_utils.jl
+++ b/src/manager/dir_utils.jl
@@ -278,8 +278,19 @@ function should_ignore(fpath::AS, files2ignore::Vector{String},
     else
         fpath = fpath[length(path(:folder))+length(PATH_SEP)+1:end]
     end
-    flag  = findfirst(c -> c == fpath, files2ignore)
-    isnothing(flag) || return true
+    files2ignore_regex = []
+    for ignore in files2ignore
+        if occursin("*", ignore)
+            ignore_str = replace(ignore, "." => "\\.")
+            ignore_str = replace(ignore_str, "*" => ".*?")
+            ignore_regex = Regex("^"*ignore_str*"\$")
+            push!(files2ignore_regex, ignore_regex)
+        else
+            push!(files2ignore_regex, ignore)
+        end
+    end
+    flag  = any(r->findfirst(r, fpath) !== nothing, files2ignore_regex)
+    flag && return true
     flag  = findfirst(c -> startswith(fpath, c), dirs2ignore)
     isnothing(flag) || return true
     return false

--- a/src/manager/dir_utils.jl
+++ b/src/manager/dir_utils.jl
@@ -103,10 +103,11 @@ The variable `verb` propagates verbosity.
 """
 function scan_input_dir!(args...; kw...)
     to_ignore = union(IGNORE_FILES, globvar("ignore"))
+    to_ignore = filter!(c-> c isa Regex ? !isempty(c.pattern) : !isempty(c), to_ignore)
     # differentiate between files and dirs
-    dir_indicator = [endswith(c, "/") for c in to_ignore]
+    dir_indicator = [c isa Regex ? endswith(c.pattern, "/") : endswith(c, "/") for c in to_ignore]
     d2i = [d for d in to_ignore[dir_indicator] if length(d) > 1]
-    f2i = filter!((!) ∘ isempty, to_ignore[.!dir_indicator])
+    f2i = to_ignore[.!dir_indicator]
 
     if FD_ENV[:STRUCTURE] < v"0.2"
         return _scan_input_dir!(args...; files2ignore=f2i, dirs2ignore=d2i)
@@ -120,8 +121,8 @@ function _scan_input_dir!(other_files::TrackedFiles,
                           html_files::TrackedFiles,
                           literate_files::TrackedFiles,
                           verb::Bool=false;
-                          files2ignore::Vector{String}=String[],
-                          dirs2ignore::Vector{String}=String[])::Nothing
+                          files2ignore::Vector=String[],
+                          dirs2ignore::Vector=String[])::Nothing
     # top level files (src/*)
     for file ∈ readdir(PATHS[:src])
         fpath = joinpath(PATHS[:src], file)
@@ -188,8 +189,8 @@ function _scan_input_dir2!(other_files::TrackedFiles,
                            literate_scripts::TrackedFiles,
                            verb::Bool=false;
                            in_loop::Bool=false,
-                           files2ignore::Vector{String}=String[],
-                           dirs2ignore::Vector{String}=String[])::Nothing
+                           files2ignore::Vector=String[],
+                           dirs2ignore::Vector=String[])::Nothing
     # go over all files in the website folder
     for (root, _, files) ∈ walkdir(path(:folder))
         for file in files
@@ -270,26 +271,15 @@ Rules:
 * `'path/fname'` -> ignore exactly that
 * `'path/dir/'`  -> ignore everything starting with `path/dir/`
 """
-function should_ignore(fpath::AS, files2ignore::Vector{String},
-                       dirs2ignore::Vector{String})::Bool
+function should_ignore(fpath::AS, files2ignore::Vector,
+                       dirs2ignore::Vector)::Bool
     # fpath is necessarily an absolute path so can strip the folder part
     if FD_ENV[:STRUCTURE] < v"0.2"
         fpath = fpath[length(path(:src))+length(PATH_SEP)+1:end]
     else
         fpath = fpath[length(path(:folder))+length(PATH_SEP)+1:end]
     end
-    files2ignore_regex = []
-    for ignore in files2ignore
-        if occursin("*", ignore)
-            ignore_str = replace(ignore, "." => "\\.")
-            ignore_str = replace(ignore_str, "*" => ".*?")
-            ignore_regex = Regex("^"*ignore_str*"\$")
-            push!(files2ignore_regex, ignore_regex)
-        else
-            push!(files2ignore_regex, ignore)
-        end
-    end
-    flag  = any(r->findfirst(r, fpath) !== nothing, files2ignore_regex)
+    flag  = any(c->c isa Regex ? match(c, fpath) !== nothing : c == fpath, files2ignore)
     flag && return true
     flag  = findfirst(c -> startswith(fpath, c), dirs2ignore)
     isnothing(flag) || return true

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -23,7 +23,7 @@ const GLOBAL_VARS_DEFAULT = [
     "date_shortdays"   => Pair(String[],     (Vector{String},)),
     "prepath"          => Pair("",           (String,)),
     # will be added to IGNORE_FILES
-    "ignore"           => Pair(String[], (Vector{String},)),
+    "ignore"           => Pair(String[], (Vector{Any},)),
     # RSS
     "website_title"    => Pair("",   (String,)),
     "website_descr"    => Pair("",   (String,)),

--- a/test/manager/dir_utils.jl
+++ b/test/manager/dir_utils.jl
@@ -3,11 +3,11 @@ fs2()
 @testset "ignore/fs2" begin
     gotd()
     s = """
-        @def ignore = ["foo.md", "path/foo.md", "dir/", "path/dir/"]
+        @def ignore = ["foo.md", "path/foo.md", "dir/", "path/dir/", "index2*"]
         """
     write(joinpath(td, "config.md"), s);
     F.process_config()
-    @test F.globvar("ignore") == ["foo.md", "path/foo.md", "dir/", "path/dir/"]
+    @test F.globvar("ignore") == ["foo.md", "path/foo.md", "dir/", "path/dir/", "index2*"]
 
     write(joinpath(td, "foo.md"), "anything")
     mkpath(joinpath(td, "path"))
@@ -17,6 +17,7 @@ fs2()
     mkpath(joinpath(td, "path", "dir"))
     write(joinpath(td, "path", "dir", "foo2.md"), "anything")
     write(joinpath(td, "index.md"), "standard things")
+    write(joinpath(td, "index2.md"), "anything")
     watched = F.fd_setup()
     @test length(watched.md) == 1
     @test first(watched.md).first.second == "index.md"

--- a/test/manager/dir_utils.jl
+++ b/test/manager/dir_utils.jl
@@ -3,11 +3,11 @@ fs2()
 @testset "ignore/fs2" begin
     gotd()
     s = """
-        @def ignore = ["foo.md", "path/foo.md", "dir/", "path/dir/", "index2*"]
+        @def ignore = ["foo.md", "path/foo.md", "dir/", "path/dir/", r"index2.*"]
         """
     write(joinpath(td, "config.md"), s);
     F.process_config()
-    @test F.globvar("ignore") == ["foo.md", "path/foo.md", "dir/", "path/dir/", "index2*"]
+    @test F.globvar("ignore") == ["foo.md", "path/foo.md", "dir/", "path/dir/", r"index2.*"]
 
     write(joinpath(td, "foo.md"), "anything")
     mkpath(joinpath(td, "path"))


### PR DESCRIPTION
Just a first approach. I actually decided to have a joker `*` which can be at any position such that `posts/*/post.md` works for example.

Problems with current approach:
- Generating the regex is not super nice maybe there is a way to escape chars. 
- The regex should probably be generated once in the `scan_input_dir!` function instead which would change `Vector{String}` to `Vector{Union{String, Regex}}`.