### PR TITLE
Use proper show in code block evaluation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,10 +31,11 @@ OrderedCollections = "1.1"
 julia = "1.1"
 
 [extras]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "DataStructures", "Random", "LinearAlgebra"]
+test = ["Test", "DataStructures", "DataFrames", "Random", "LinearAlgebra"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.8.1"
+version = "0.8.2"
 
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"

--- a/src/eval/codeblock.jl
+++ b/src/eval/codeblock.jl
@@ -109,11 +109,11 @@ function resolve_code_block(ss::SubString)::String
         # >> eval the code in the relevant module (this creates output/)
         res = run_code(mod, code, cp.out_path; strip_code=false)
         # >> write res to file
-        open(cp.res_path, "w") do resf
-            redirect_stdout(resf) do
-                show(stdout, "text/plain", res)
-            end
-        end
+        # >> this weird thing is to make sure that the proper "show"
+        #    is called...
+        io = IOBuffer()
+        Core.eval(mod, quote show($io, "text/plain", $res) end)
+        write(cp.res_path, take!(io))
         # >> since we've evaluated a code block, toggle scope as stale
         set_var!(LOCAL_VARS, "fd_eval", true)
     end

--- a/test/eval/extras.jl
+++ b/test/eval/extras.jl
@@ -45,3 +45,31 @@ fs2()
         <p>ABC <p><span style="color:red;">// Image matching '/assets/blog/kaggle/baz.png' not found. //</span></p></p>
         """)
 end
+
+
+@testset "show" begin
+    s = """
+    @def showall=true
+    ```julia:ex
+    using DataFrames
+    df = DataFrame(A = 1:4, B = ["M", "F", "F", "M"])
+    first(df, 3)
+    ```
+    """ |> fd2html_td
+    @test isapproxstr(s, """
+        <pre><code class="language-julia">
+        using DataFrames
+        df = DataFrame(A = 1:4, B = ["M", "F", "F", "M"])
+        first(df, 3)
+        </code></pre>
+        <pre><code class="plaintext">
+        3×2 DataFrames.DataFrame
+        │ Row │ A     │ B      │
+        │     │ Int64 │ String │
+        ├─────┼───────┼────────┤
+        │ 1   │ 1     │ M      │
+        │ 2   │ 2     │ F      │
+        │ 3   │ 3     │ F      │
+        </code></pre>
+        """)
+end


### PR DESCRIPTION
So it turns out that making absolutely sure the right `show` method is called is  not trivial. E.g. this code:

```
using DataFrames
df = DataFrame(A = 1:4, B = ["M", "F", "F", "M"])
first(df, 3)
```

on a Franklin page called in an env that does not import `DataFrames` would have shown the raw object in the past when we would have wanted the nice

```
3×2 DataFrames.DataFrame
│ Row │ A     │ B      │
│     │ Int64 │ String │
├─────┼───────┼────────┤
│ 1   │ 1     │ M      │
│ 2   │ 2     │ F      │
│ 3   │ 3     │ F      │
```

The `Core.eval` is probably overkill but ensures that the show command is exactly run in the temporary module (which does have the proper show method).