### PR TITLE
Custom content

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"

--- a/src/converter/markdown/tags.jl
+++ b/src/converter/markdown/tags.jl
@@ -109,6 +109,8 @@ that the user has to modify it. This will help users transition when they may
 have used a template that did not define `_layout/tag.html`.
 """
 function write_default_tag_layout()::Nothing
+    dc = globvar("div_content")
+    dc = ifelse(isempty(dc), globvar("content_class"), dc)
     html = """
         <!doctype html>
         <html lang="en">
@@ -118,7 +120,7 @@ function write_default_tag_layout()::Nothing
           <title>Tag: {{fill fd_tag}}</title>
         </head>
         <body>
-          <div class="{{div_content}} tagpage">
+          <div class="$dc tagpage">
             {{taglist}}
           </div>
         </body>

--- a/src/converter/markdown/tags.jl
+++ b/src/converter/markdown/tags.jl
@@ -84,7 +84,6 @@ Internal function to (re)write the tag pages corresponding to `update_tags`.
 """
 function write_tag_page(tag)::Nothing
     # make `fd_tag` available to that page generation
-    # also allows {{istag tagname}} ... {{end}}
     set_var!(LOCAL_VARS, "fd_tag", tag)
 
     layout_key  = ifelse(FD_ENV[:STRUCTURE] < v"0.2", :src_html, :layout)

--- a/src/manager/file_utils.jl
+++ b/src/manager/file_utils.jl
@@ -85,7 +85,7 @@ function write_page(root::String, file::String, head::String,
     # f1/blah/page1.md or index.md etc... this is useful in the code evaluation
     # and management of paths
     set_cur_rpath(fpath)
-    # conversion    
+    # conversion
     content = convert_md(read(fpath, String))
 
     # Check if should add item
@@ -230,8 +230,22 @@ $(SIGNATURES)
 
 Convenience function to assemble the html out of its parts.
 """
-build_page(head::String, content::String, pgfoot::String, foot::String) =
-    head * html_hk(locvar("tag_content"), content * pgfoot;class=locvar("div_content")) * foot
+function build_page(head, content, pgfoot, foot)
+    # (legacy support) if div_content is offered explicitly, it takes
+    # precedence
+    dc = globvar("div_content")
+    if isempty(dc)
+        content_tag   = globvar("content_tag")
+        content_class = globvar("content_class")
+        content_id    = globvar("content_id")
+    else
+        content_tag   = "div"
+        content_class = dc
+        content_id    = ""
+    end
+    return head * html_content(content_tag, content * pgfoot;
+                               class=content_class, id=content_id) * foot
+end
 
 
 """

--- a/src/utils/html.jl
+++ b/src/utils/html.jl
@@ -2,10 +2,15 @@
 attr(name::Symbol, val::AS) = ifelse(isempty(val), "", " $name=\"$val\"")
 
 """Convenience function for a sup item."""
-html_sup(id::String, in::AS) =  "<sup id=\"$id\">$in</sup>"
+html_sup(id::String, in::AS) = "<sup id=\"$id\">$in</sup>"
 
 """Convenience function for a header."""
-html_hk(hk::String, t::AS; id::String="", class::String="") = "<$hk$(attr(:id, id))$(attr(:class, class))>$t</$hk>"
+html_hk(hk::String, t::AS; id::String="", class::String="") =
+    "<$hk$(attr(:id, id))>$t</$hk>"
+
+"""Convenience function for content tagging (see `build_page`)"""
+html_content(tag::String, content::AS; class::String, id::String) =
+   "<$tag$(attr(:class, class))$(attr(:id, id))>$content</$tag>"
 
 """Convenience function to introduce a hyper reference."""
 function html_ahref(link::AS, name::Union{Int,AS};

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -30,14 +30,17 @@ const GLOBAL_VARS_DEFAULT = [
     "website_url"      => Pair("",   (String,)),
     "generate_rss"     => Pair(true, (Bool,)),
     # div names
-    "tag_content"      => Pair("div",              (String,)),
-    "div_content"      => Pair("franklin-content", (String,)),
+    "content_tag"      => Pair("div",              (String,)),
+    "content_class"    => Pair("franklin-content", (String,)),
+    "content_id"       => Pair("",                 (String,)),
     # auto detection of code / math (see hasmath/hascode)
     "autocode"         => Pair(true, (Bool,)),
     "automath"         => Pair(true, (Bool,)),
     # keep track page=>tags and tag=>pages
     "fd_page_tags"     => Pair(nothing, (DTAG,  Nothing)),
     "fd_tag_pages"     => Pair(nothing, (DTAGI, Nothing)),
+    # LEGACY
+    "div_content" => Pair("", (String,)), # see build_page
     ]
 
 """

--- a/test/utils/html.jl
+++ b/test/utils/html.jl
@@ -63,4 +63,6 @@ end
 end
 
 @testset "html_content" begin
+    h = F.html_content("div", "foo bar"; class="container", id="body")
+    @test h == "<div class=\"container\" id=\"body\">foo bar</div>"
 end

--- a/test/utils/html.jl
+++ b/test/utils/html.jl
@@ -61,3 +61,6 @@ end
         a = randn()
         b = a + 5</code></pre>"""
 end
+
+@testset "html_content" begin
+end


### PR DESCRIPTION
@findmyway could I get you to review this? I think it does what you want; it's also backward compatible in that if people set `div_content` (as before) it will just take precedence and do the same stuff as before.

I also changed the namings to `content_tag`, `content_class` , `content_id` which I thought was clearer and more readable than writing it the other way (`tag_content` for instance is confusing with tag pages)

Let me know what you think and I'll bring this in