### PR TITLE
Simple redirects

### DIFF
--- a/src/manager/franklin.jl
+++ b/src/manager/franklin.jl
@@ -80,6 +80,10 @@ function serve(; clear::Bool=false,
     FD_ENV[:STRUCTURE] = fsv
 
     if FD_ENV[:STRUCTURE] < v"0.2"
+        @warn "You seem to be using Franklin's old file structure which is now " *
+              "deprecated, please consider upgrading to the new file structure, " *
+              "see https://github.com/tlienart/Franklin.jl/blob/master/NEWS.md#v06-1 " *
+              "for details."
         # check to see if we're in a folder that has the right structure,
         # otherwise stop and tell the user to check (#155)
         if !isdir(joinpath(FOLDER_PATH[], "src"))

--- a/src/utils/paths.jl
+++ b/src/utils/paths.jl
@@ -11,8 +11,8 @@ IGNORE_FILES
 
 Collection of file names that will be ignored at compile time.
 """
-const IGNORE_FILES = [".DS_Store", ".gitignore", "LICENSE.md", "README.md",
-                      "franklin", "franklin.pub", "node_modules/"]
+const IGNORE_FILES = (".DS_Store", ".gitignore", "LICENSE.md", "README.md",
+                      "franklin", "franklin.pub", "node_modules/")
 
 
 """

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -93,8 +93,8 @@ const LOCAL_VARS_DEFAULT = [
     # MISCELLANEOUS (should not be modified)
     "fd_ctime"  => Pair(Date(1),    (Date,)),   # time of creation
     "fd_mtime"  => Pair(Date(1),    (Date,)),   # time of last modification
-    "fd_rpath"  => Pair("",         (String,)), # rpath to current page
-    "fd_url"    => Pair("",         (String,)), # url to current page
+    "fd_rpath"  => Pair("",         (String,)), # rpath to current page [1]
+    "fd_url"    => Pair("",         (String,)), # url to current page [2]
     "fd_tag"    => Pair("",         (String,)), # (generated) current tag
     ]
 #=
@@ -110,6 +110,9 @@ NOTE:
     (*) guid        -- [automatically generated from link]
         pubDate     -- rss_pubdate // fallback date // fallback fd_ctime
     (*) source      -- [unsupported assumes for now there's only one channel]
+
+[1] e.g.: blog/kaggle.md
+[2] e.g.: blog/kaggle/index.html
 =#
 
 """

--- a/test/integration/hfuns.jl
+++ b/test/integration/hfuns.jl
@@ -1,0 +1,31 @@
+@testset "redirect" begin
+    gotd()
+    write(joinpath(td, "config.md"), "")
+    mkpath(joinpath(td, "_css"))
+    mkpath(joinpath(td, "_layout"))
+    write(joinpath(td, "_layout", "head.html"), "")
+    write(joinpath(td, "_layout", "foot.html"), "")
+    write(joinpath(td, "_layout", "page_foot.html"), "")
+    write(joinpath(td, "foo.md"), """
+    {{redirect bar/foo.html}}
+    {{redirect bar.html}}
+    # Hello
+    baz
+    """)
+    write(joinpath(td, "index.md"), """
+    # Index
+    """)
+    serve(single=true)
+    @test isfile(joinpath("__site", "index.html"))
+    @test isfile(joinpath("__site", "foo", "index.html"))
+    @test isfile(joinpath("__site", "bar.html"))
+    @test isfile(joinpath("__site", "bar", "foo.html"))
+    @test read(joinpath("__site", "bar", "foo.html"), String) // """
+                    <!-- Generated Redirect -->
+                    <!doctype html>
+                    <html>
+                    <head>
+                      <meta http-equiv="refresh" content="0; url=/foo/index.html">
+                    </head>
+                    </html>"""
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,6 +115,7 @@ println("INTEGRATION")
 include("integration/literate.jl")
 include("integration/literate_fs2.jl")
 include("integration/literate_extras.jl")
+include("integration/hfuns.jl")
 
 flush_td()
 cd(joinpath(dirname(dirname(pathof(Franklin)))))


### PR DESCRIPTION
```
{{redirect some/path.html}}
```

will add `[site]/some/path.html` and link to the page that has the hfun.

assumption: `some/path.html` does not clash (if it doesn't, whatever exists will stay as is and the redirect will not be created).