### PR TITLE
Allow the `git commit` to fail

### DIFF
--- a/src/manager/post_processing.jl
+++ b/src/manager/post_processing.jl
@@ -265,7 +265,7 @@ function publish(; prerender::Bool=true, minify::Bool=true, nopass::Bool=false,
         print(pubmsg)
         try
             run(`git add -A `)
-            run(`git commit -m "$message" --quiet`)
+            wait(run(`git commit -m "$message" --quiet`; wait=false))
             if do_push
                 run(`git push --quiet`)
             end


### PR DESCRIPTION
If there is nothing to commit, the `git commit` command will exit with a nonzero exit code. This change allows the `publish` function to succeed even if there is nothing new to commit.