### PR TITLE
Add Julia 1.5 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 julia:
   - 1.3
   - 1.4
+  - 1.5
   - nightly
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
 julia:
   - 1.3
-  - 1.4
   - 1.5
   - nightly
 matrix:


### PR DESCRIPTION
Maybe 1.3 should be dropped too, since it isn't supported anymore (neither LTS nor stable release). (But it's the lower bound in `Project.toml`.)