### PR TITLE
Removing redundant unique call before making Set

### DIFF
--- a/src/converter/markdown/mddefs.jl
+++ b/src/converter/markdown/mddefs.jl
@@ -64,7 +64,7 @@ function process_mddefs(blocks::Vector{OCBlock}, isconfig::Bool,
     (:process_mddefs, "assignments done & copy to ALL_PAGE_VARS") |> logger
 
     # TAGS
-    tags = Set(unique(locvar(:tags)))
+    tags = Set(locvar(:tags))
     # Cases:
     # 0. there was no page tags before
     #   a. tags is empty --> do nothing


### PR DESCRIPTION
Removing a call to `unique` before making a Set of the local tags.