### PR TITLE
(#580) allow {{var}} in for loop

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.9.2"
+version = "0.9.3"
 
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"

--- a/src/converter/html/blocks.jl
+++ b/src/converter/html/blocks.jl
@@ -200,8 +200,8 @@ function process_html_for(hs::AS, qblocks::Vector{AbstractBlock},
     # check that the first element of the iterate has the same length
     el1 = first(iter)
     length(vnames) in (1, length(el1)) ||
-        throw(HTMLBlockError("In a {{for ...}}, the first element of" *
-                "the iterate has length $(length(el1)) but tried to unpack" *
+        throw(HTMLBlockError("In a {{for ...}}, the first element of " *
+                "the iterate has length $(length(el1)) but tried to unpack " *
                 "it as $(length(vnames)) variables."))
 
     # so now basically we have to simply copy-paste the content replacing
@@ -214,8 +214,8 @@ function process_html_for(hs::AS, qblocks::Vector{AbstractBlock},
     isempty(strip(inner)) && @goto final_step
     content = ""
     if length(vnames) == 1
-        rx1 = Regex("{{\\s*fill\\s+$vname\\s*}}")           # {{ fill v}}
-        rx2 = Regex("{{\\s*fill\\s+(\\S+)\\s+$vname\\s*}}") # {{ fill x v}}
+        rx1 = Regex("{{\\s*(?:fill\\s)?\\s*$vname\\s*}}")           # {{ fill v}} or {{v}}
+        rx2 = Regex("{{\\s*(?:fill\\s)?\\s*(\\S+)\\s+$vname\\s*}}") # {{ fill x v}}
         for v in iter
             # at the moment we only consider {{fill ...}}
             tmp = replace(inner, rx1 => "$v")
@@ -226,8 +226,8 @@ function process_html_for(hs::AS, qblocks::Vector{AbstractBlock},
         for values in iter # each element of the iter can be unpacked
             tmp = inner
             for (vname, v) in zip(vnames, values)
-                rx1 = Regex("{{\\s*fill\\s+$vname\\s*}}")
-                rx2 = Regex("{{\\s*fill\\s+(\\S+)\\s+$vname\\s*}}")
+                rx1 = Regex("{{\\s*(?:fill\\s)?\\s*$vname\\s*}}")
+                rx2 = Regex("{{\\s*(?:fill\\s)\\s*(\\S+)\\s+$vname\\s*}}")
                 tmp = replace(tmp, rx1 => "$v")
                 tmp = replace(tmp, rx2 => SubstitutionString("{{fill \\1 $v}}"))
             end

--- a/test/converter/html/html_for.jl
+++ b/test/converter/html/html_for.jl
@@ -82,3 +82,39 @@ end
         value:3
         """)
 end
+
+
+# read from file, see FranklinFAQ-001
+@testset "for-file" begin
+    gotd()
+    write("members.csv", """
+    name,github
+    Eric Mill,konklone
+    Parker Moore,parkr
+    Liu Fengyun,liufengyun
+    """)
+    s = """
+        @def members = eachrow(readdlm("members.csv", ',', skipstart=1))
+        ~~~
+        <ul>
+        {{for (name, alias) in members}}
+          <li>
+            <a href="https://github.com/{{alias}}">{{name}}</a>
+          </li>
+        {{end}}
+        </ul>
+        ~~~
+        """ |> fd2html
+    @test isapproxstr(s, """
+                <ul>
+                  <li>
+                    <a href="https://github.com/konklone">Eric Mill</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/parkr">Parker Moore</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/liufengyun">Liu Fengyun</a>
+                  </li>
+                </ul>""")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Franklin, Test, Markdown, Dates, Random, Literate
+using Franklin, Test, Markdown, Dates, Random, Literate, DelimitedFiles
 const F = Franklin
 const R = @__DIR__
 const D = joinpath(dirname(dirname(pathof(Franklin))), "test", "_dummies")


### PR DESCRIPTION
Allows

```
{{for (name, alias) in members}}
   stuff with {{name}} and with {{alias}}
{{end}}
```

where in the past it would only have been `{{fill name}}` and `{{fill alias}}`. 

Actually now `{{name page/path}}` is also allowed though not very clear so probably not recommended.