### PR TITLE
Support for Pagination (issue #496)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.9.3"
+version = "0.9.4"
 
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"

--- a/src/Franklin.jl
+++ b/src/Franklin.jl
@@ -60,7 +60,8 @@ const FD_ENV = LittleDict(
     :SILENT_MODE   => false,
     :OFFSET_LXDEFS => -BIG_INT,
     :CUR_PATH      => "",
-    :STRUCTURE     => v"0.2")
+    :STRUCTURE     => v"0.2",
+    :QUIET_TEST    => false,)
 
 """Dict to keep track of languages and how comments are indicated and their extensions. This is relevant to allow hiding lines of code. """
 const CODE_LANG = LittleDict{String,NTuple{2,String}}(

--- a/src/Franklin.jl
+++ b/src/Franklin.jl
@@ -173,6 +173,7 @@ include("converter/html/prerender.jl")
 
 # FILE AND DIR MANAGEMENT
 include("manager/rss_generator.jl")
+include("manager/write_page.jl")
 include("manager/dir_utils.jl")
 include("manager/file_utils.jl")
 include("manager/franklin.jl")

--- a/src/converter/html/functions.jl
+++ b/src/converter/html/functions.jl
@@ -84,7 +84,7 @@ function hfun_insert(params::Vector{String})::String
     end
     # apply
     repl   = ""
-    layout = path(ifelse(FD_ENV[:STRUCTURE] < v"0.2", :src_html, :layout))
+    layout = path(layout_key())
     fpath  = joinpath(layout, split(params[1], "/")...)
     if isfile(fpath)
         repl = convert_html(read(fpath, String))

--- a/src/converter/html/link_fixer.jl
+++ b/src/converter/html/link_fixer.jl
@@ -74,7 +74,9 @@ should eventually be pre-prended with `/project/`. This would happen just
 before you publish the website.
 """
 function fix_links(pg::String)::String
-    pp = strip(GLOBAL_VARS["prepath"].first, '/')
+    prepath = globvar(:prepath)
+    isempty(prepath) && return pg
+    pp = strip(prepath, '/')
     ss = SubstitutionString("\\1=\"/$(pp)/")
     return replace(pg, r"(src|href|formaction)\s*?=\s*?\"\/" => ss)
 end

--- a/src/converter/markdown/tags.jl
+++ b/src/converter/markdown/tags.jl
@@ -86,9 +86,8 @@ function write_tag_page(tag)::Nothing
     # make `fd_tag` available to that page generation
     set_var!(LOCAL_VARS, "fd_tag", tag)
 
-    layout_key  = ifelse(FD_ENV[:STRUCTURE] < v"0.2", :src_html, :layout)
-    layout      = path(layout_key)
-    content     = read(joinpath(layout, "tag.html"), String)
+    layout  = path(layout_key())
+    content = read(joinpath(layout, "tag.html"), String)
 
     dir = joinpath(path(:tag), tag)
     isdir(dir) || mkdir(dir)

--- a/src/manager/file_utils.jl
+++ b/src/manager/file_utils.jl
@@ -68,81 +68,6 @@ end
 """
 $(SIGNATURES)
 
-Take a path to an input markdown file (via `root` and `file`), then construct
-the appropriate HTML page (inserting `head`, `pg_foot` and `foot`) and finally
-write it at the appropriate place.
-"""
-function write_page(root::String, file::String, head::String,
-                    pg_foot::String, foot::String, out_path::String;
-                    prerender::Bool=false, isoptim::Bool=false,
-                    on_write::Function=(_,_)->nothing)::Nothing
-    # 1. read the markdown into string, convert it and extract definitions
-    # 2. eval the definitions and update the variable dictionary, also retrieve
-    # document variables (time of creation, time of last modif) and add those
-    # to the dictionary.
-    fpath = joinpath(root, file)
-    # The curpath is the relative path starting after /src/ so for instance:
-    # f1/blah/page1.md or index.md etc... this is useful in the code evaluation
-    # and management of paths
-    set_cur_rpath(fpath)
-    # conversion
-    content = convert_md(read(fpath, String))
-
-    # Check if should add item
-    #   should we generate ? otherwise no
-    #   are we in the full pass ? otherwise no
-    #   is there a `rss` or `rss_description` ? otherwise no
-    cond_add = GLOBAL_VARS["generate_rss"].first && # should we generate?
-                FD_ENV[:FULL_PASS] &&               # are we in the full pass?
-                !all(e -> isempty(locvar(e)), ("rss", "rss_description"))
-    # otherwise yes
-    cond_add && add_rss_item()
-
-    # adding document variables to the dictionary
-    # note that some won't change and so it's not necessary to do this every
-    # time but it takes negligible time to do this so ¯\_(ツ)_/¯
-    # (and it's less annoying than keeping tabs on which file has
-    # already been treated etc).
-    s = stat(fpath)
-    set_var!(LOCAL_VARS, "fd_ctime", fd_date(unix2datetime(s.ctime)))
-    set_var!(LOCAL_VARS, "fd_mtime", fd_date(unix2datetime(s.mtime)))
-
-    # 3. process blocks in the html infra elements based on `LOCAL_VARS`
-    # (e.g.: add the date in the footer)
-    content = convert_html(str(content))
-    head, pg_foot, foot = (e -> convert_html(e)).([head, pg_foot, foot])
-
-    # 4. construct the page proper & prerender if needed
-    pg = build_page(head, content, pg_foot, foot)
-    if prerender
-        # KATEX
-        pg = js_prerender_katex(pg)
-        # HIGHLIGHT
-        if FD_CAN_HIGHLIGHT
-            pg = js_prerender_highlight(pg)
-            # remove script
-            pg = replace(pg, r"<script.*?(?:highlight\.pack\.js|initHighlightingOnLoad).*?<\/script>"=>"")
-        end
-        # remove katex scripts
-        pg = replace(pg, r"<script.*?(?:katex\.min\.js|auto-render\.min\.js|renderMathInElement).*?<\/script>"=>"")
-    end
-    # append pre-path if required (see optimize)
-    if !isempty(GLOBAL_VARS["prepath"].first) && isoptim
-        pg = fix_links(pg)
-    end
-
-    # 5. write the html file where appropriate
-    write(out_path, pg)
-
-    # 6. possible post-processing via the "on-write" function.
-    on_write(pg, LOCAL_VARS)
-    return nothing
-end
-
-
-"""
-$(SIGNATURES)
-
 See [`process_file_err`](@ref).
 """
 function process_file(case::Symbol, fpair::Pair{String,String}, args...;
@@ -185,7 +110,7 @@ function process_file_err(
     inp  = joinpath(fpair...)
     outp = form_output_path(fpair.first, fpair.second, case)
     if case == :md
-        write_page(fpair..., head, pgfoot, foot, outp;
+        convert_and_write(fpair..., head, pgfoot, foot, outp;
                    prerender=prerender, isoptim=isoptim, on_write=on_write)
     elseif case == :html
         set_cur_rpath(joinpath(fpair...))
@@ -223,29 +148,6 @@ $(SIGNATURES)
 Convenience function to replace the extension of a filename with another.
 """
 change_ext(fname::AS, ext=".html")::String = splitext(fname)[1] * ext
-
-
-"""
-$(SIGNATURES)
-
-Convenience function to assemble the html out of its parts.
-"""
-function build_page(head, content, pgfoot, foot)
-    # (legacy support) if div_content is offered explicitly, it takes
-    # precedence
-    dc = globvar("div_content")
-    if isempty(dc)
-        content_tag   = globvar("content_tag")
-        content_class = globvar("content_class")
-        content_id    = globvar("content_id")
-    else
-        content_tag   = "div"
-        content_class = dc
-        content_id    = ""
-    end
-    return head * html_content(content_tag, content * pgfoot;
-                               class=content_class, id=content_id) * foot
-end
 
 
 """

--- a/src/manager/file_utils.jl
+++ b/src/manager/file_utils.jl
@@ -82,8 +82,7 @@ function process_file(case::Symbol, fpair::Pair{String,String}, args...;
     catch err
         rp = fpair.first
         rp = rp[end-min(20, length(rp))+1 : end]
-        println("\n... encountered an issue processing '$(fpair.second)' " *
-                "in ...$rp. Verify, then start franklin again...\n")
+        FD_ENV[:QUIET_TEST] || println("\n... encountered an issue processing '$(fpair.second)' in ...$rp. Verify, then start franklin again...\n")
         FD_ENV[:SUPPRESS_ERR] || throw(err)
         return -1
     end

--- a/src/manager/franklin.jl
+++ b/src/manager/franklin.jl
@@ -31,7 +31,7 @@ Keyword arguments:
 * `nomess=false`:    suppresses all messages (internal use).
 * `isoptim=false`:   whether we're in an optimisation phase or not (if so,
                       links are fixed in case of a project website, see
-                      [`write_page`](@ref).
+                      [`convert_and_write`](@ref).
 * `no_fail_prerender=true`: whether, in a prerendering phase, ignore errors and
                       try to produce an output
 * `eval_all=false`:  whether to force re-evaluation of all code blocks

--- a/src/manager/franklin.jl
+++ b/src/manager/franklin.jl
@@ -224,9 +224,8 @@ function fd_fullpass(watched_files::NamedTuple; clear::Bool=false,
 
     # form page segments
     root_key   = ifelse(FD_ENV[:STRUCTURE] < v"0.2", :src, :folder)
-    layout_key = ifelse(FD_ENV[:STRUCTURE] < v"0.2", :src_html, :layout)
     root       = path(root_key)
-    layout     = path(layout_key)
+    layout     = path(layout_key())
 
     head    = read(joinpath(layout, "head.html"),      String)
     pg_foot = read(joinpath(layout, "page_foot.html"), String)
@@ -308,8 +307,7 @@ function fd_loop(cycle_counter::Int, ::LiveServer.FileWatcher,
         # update the dictionaries
         scan_input_dir!(watched_files..., verb; in_loop=true)
     else
-        layout_key = ifelse(FD_ENV[:STRUCTURE] < v"0.2", :src_html, :layout)
-        layout     = path(layout_key)
+        layout = path(layout_key())
         # do a pass over the files, check if one has changed and if so trigger
         # the appropriate file processing mechanism
         for (case, dict) ∈ pairs(watched_files), (fpair, t) ∈ dict

--- a/src/manager/write_page.jl
+++ b/src/manager/write_page.jl
@@ -78,7 +78,6 @@ function write_page(output_path::AS, content::AS;
 end
 
 
-
 """
 $(SIGNATURES)
 

--- a/src/manager/write_page.jl
+++ b/src/manager/write_page.jl
@@ -1,0 +1,125 @@
+"""
+$(SIGNATURES)
+
+Convenience function to assemble the html of a page out of its parts:
+- head
+- content and pgfoot (which will be wrapped to form the body)
+- foot.
+"""
+function build_page(head, content, pgfoot, foot)
+    # (legacy support) if div_content is offered explicitly, it takes
+    # precedence, otherwise use defaults
+    dc = globvar("div_content")
+    if isempty(dc)
+        content_tag   = globvar("content_tag")
+        content_class = globvar("content_class")
+        content_id    = globvar("content_id")
+    else
+        content_tag   = "div"
+        content_class = dc
+        content_id    = ""
+    end
+    # wrap the body in appropriate tags
+    body = html_content(content_tag, content * pgfoot;
+                        class=content_class, id=content_id)
+    return head * body * foot
+end
+
+
+"""
+$(SIGNATURES)
+
+Write a html page at the appropriate location and with the appropriate structure.
+This is usually called specifying the scaffolding but can be done without in which
+"""
+function write_page(rpath::AS, content::AS;
+                    head::T=nothing, pg_foot::T=nothing, foot::T=nothing
+                    )::Nothing where T <: Union{Nothing,AS}
+    # NOTE
+    #   - rpath is assumed to exist // see form_output_path
+    #   - head/pg_foot/foot === nothing --> read (see franklin.jl)
+    #   - string (possibly empty), use as such
+    isnothing(head)    && (head    = read(joinpath(layout, "head.html"),      String))
+    isnothing(pg_foot) && (pg_foot = read(joinpath(layout, "page_foot.html"), String))
+    isnothing(foot)    && (foot    = read(joinpath(layout, "foot.html"),      String))
+
+    page_html = build_page(head, content, pgfoot, foot)
+
+    return
+end
+
+
+
+"""
+$(SIGNATURES)
+
+Take a path to an input markdown file (via `root` and `file`), then construct
+the appropriate HTML page (inserting `head`, `pg_foot` and `foot`) and finally
+write it at the appropriate place.
+"""
+function convert_and_write(root::String, file::String, head::String,
+                    pg_foot::String, foot::String, out_path::String;
+                    prerender::Bool=false, isoptim::Bool=false,
+                    on_write::Function=(_,_)->nothing)::Nothing
+    # 1. read the markdown into string, convert it and extract definitions
+    # 2. eval the definitions and update the variable dictionary, also retrieve
+    # document variables (time of creation, time of last modif) and add those
+    # to the dictionary.
+    fpath = joinpath(root, file)
+    # The curpath is the relative path starting after /src/ so for instance:
+    # f1/blah/page1.md or index.md etc... this is useful in the code evaluation
+    # and management of paths
+    set_cur_rpath(fpath)
+    # conversion
+    content = convert_md(read(fpath, String))
+
+    # Check if should add item
+    #   should we generate ? otherwise no
+    #   are we in the full pass ? otherwise no
+    #   is there a `rss` or `rss_description` ? otherwise no
+    cond_add = GLOBAL_VARS["generate_rss"].first &&     # should we generate?
+                    FD_ENV[:FULL_PASS] &&               # are we in the full pass?
+                    !all(e -> isempty(locvar(e)), ("rss", "rss_description"))
+    # otherwise yes
+    cond_add && add_rss_item()
+
+    # adding document variables to the dictionary
+    # note that some won't change and so it's not necessary to do this every
+    # time but it takes negligible time to do this so ¯\_(ツ)_/¯
+    # (and it's less annoying than keeping tabs on which file has
+    # already been treated etc).
+    s = stat(fpath)
+    set_var!(LOCAL_VARS, "fd_ctime", fd_date(unix2datetime(s.ctime)))
+    set_var!(LOCAL_VARS, "fd_mtime", fd_date(unix2datetime(s.mtime)))
+
+    # 3. process blocks in the html infra elements based on `LOCAL_VARS`
+    # (e.g.: add the date in the footer)
+    content = convert_html(str(content))
+    head, pg_foot, foot = (e -> convert_html(e)).([head, pg_foot, foot])
+
+    # 4. construct the page proper & prerender if needed
+    pg = build_page(head, content, pg_foot, foot)
+    if prerender
+        # KATEX
+        pg = js_prerender_katex(pg)
+        # HIGHLIGHT
+        if FD_CAN_HIGHLIGHT
+            pg = js_prerender_highlight(pg)
+            # remove script
+            pg = replace(pg, r"<script.*?(?:highlight\.pack\.js|initHighlightingOnLoad).*?<\/script>"=>"")
+        end
+        # remove katex scripts
+        pg = replace(pg, r"<script.*?(?:katex\.min\.js|auto-render\.min\.js|renderMathInElement).*?<\/script>"=>"")
+    end
+    # append pre-path if required (see optimize)
+    if !isempty(GLOBAL_VARS["prepath"].first) && isoptim
+        pg = fix_links(pg)
+    end
+
+    # 5. write the html file where appropriate
+    write(out_path, pg)
+
+    # 6. possible post-processing via the "on-write" function.
+    on_write(pg, LOCAL_VARS)
+    return nothing
+end

--- a/src/manager/write_page.jl
+++ b/src/manager/write_page.jl
@@ -20,6 +20,7 @@ function build_page(head, content, pgfoot, foot)
         content_id    = ""
     end
     # wrap the body in appropriate tags
+    # <$tag class=$cclass>$content</$tag>
     body = html_content(content_tag, content * pgfoot;
                         class=content_class, id=content_id)
     return head * body * foot
@@ -29,23 +30,51 @@ end
 """
 $(SIGNATURES)
 
-Write a html page at the appropriate location and with the appropriate structure.
-This is usually called specifying the scaffolding but can be done without in which
+Write a html page at the appropriate location and with the appropriate
+structure. This is usually called specifying the scaffolding but can be done
+without in which case the scaffolding is read from `layout`.
 """
-function write_page(rpath::AS, content::AS;
-                    head::T=nothing, pg_foot::T=nothing, foot::T=nothing
-                    )::Nothing where T <: Union{Nothing,AS}
+function write_page(output_path::AS, content::AS;
+                    head::T=nothing, pgfoot::T=nothing, foot::T=nothing,
+                    prerender::Bool=false, isoptim::Bool=false
+                    )::String where T <: Union{Nothing,AS}
     # NOTE
-    #   - rpath is assumed to exist // see form_output_path
-    #   - head/pg_foot/foot === nothing --> read (see franklin.jl)
-    #   - string (possibly empty), use as such
-    isnothing(head)    && (head    = read(joinpath(layout, "head.html"),      String))
-    isnothing(pg_foot) && (pg_foot = read(joinpath(layout, "page_foot.html"), String))
-    isnothing(foot)    && (foot    = read(joinpath(layout, "foot.html"),      String))
+    #   - output_path is assumed to exist // see form_output_path
+    #   - head/pgfoot/foot === nothing --> read (see franklin.jl)
+    layout = path(layout_key())
+    if isnothing(head)
+        head = read(joinpath(layout, "head.html"), String)
+    end
+    if isnothing(pgfoot)
+        pgfoot = read(joinpath(layout, "page_foot.html"), String)
+    end
+    if isnothing(foot)
+        foot = read(joinpath(layout, "foot.html"), String)
+    end
+    # convert any `{{...}}` that may be left and form the full page string
+    pg = build_page(map(convert_html, (head, content, pgfoot, foot))...)
 
-    page_html = build_page(head, content, pgfoot, foot)
+    # Prerender if required (using JS tools)
+    if prerender
+        # Maths (KATEX)
+        pg = js_prerender_katex(pg)
+        # Code (HIGHLIGHT.JS)
+        if FD_CAN_HIGHLIGHT
+            pg = js_prerender_highlight(pg)
+            # remove script
+            pg = replace(pg, r"<script.*?(?:highlight\.pack\.js|initHighlightingOnLoad).*?<\/script>"=>"")
+        end
+        # remove katex scripts
+        pg = replace(pg, r"<script.*?(?:katex\.min\.js|auto-render\.min\.js|renderMathInElement).*?<\/script>" => "")
+    end
+    # append pre-path to links if required (see optimize)
+    if !isempty(GLOBAL_VARS["prepath"].first) && isoptim
+        pg = fix_links(pg)
+    end
 
-    return
+    # 5. write the html file where appropriate
+    write(output_path, pg)
+    return pg
 end
 
 
@@ -54,11 +83,11 @@ end
 $(SIGNATURES)
 
 Take a path to an input markdown file (via `root` and `file`), then construct
-the appropriate HTML page (inserting `head`, `pg_foot` and `foot`) and finally
+the appropriate HTML page (inserting `head`, `pgfoot` and `foot`) and finally
 write it at the appropriate place.
 """
 function convert_and_write(root::String, file::String, head::String,
-                    pg_foot::String, foot::String, out_path::String;
+                    pgfoot::String, foot::String, output_path::String;
                     prerender::Bool=false, isoptim::Bool=false,
                     on_write::Function=(_,_)->nothing)::Nothing
     # 1. read the markdown into string, convert it and extract definitions
@@ -92,32 +121,8 @@ function convert_and_write(root::String, file::String, head::String,
     set_var!(LOCAL_VARS, "fd_ctime", fd_date(unix2datetime(s.ctime)))
     set_var!(LOCAL_VARS, "fd_mtime", fd_date(unix2datetime(s.mtime)))
 
-    # 3. process blocks in the html infra elements based on `LOCAL_VARS`
-    # (e.g.: add the date in the footer)
-    content = convert_html(str(content))
-    head, pg_foot, foot = (e -> convert_html(e)).([head, pg_foot, foot])
-
-    # 4. construct the page proper & prerender if needed
-    pg = build_page(head, content, pg_foot, foot)
-    if prerender
-        # KATEX
-        pg = js_prerender_katex(pg)
-        # HIGHLIGHT
-        if FD_CAN_HIGHLIGHT
-            pg = js_prerender_highlight(pg)
-            # remove script
-            pg = replace(pg, r"<script.*?(?:highlight\.pack\.js|initHighlightingOnLoad).*?<\/script>"=>"")
-        end
-        # remove katex scripts
-        pg = replace(pg, r"<script.*?(?:katex\.min\.js|auto-render\.min\.js|renderMathInElement).*?<\/script>"=>"")
-    end
-    # append pre-path if required (see optimize)
-    if !isempty(GLOBAL_VARS["prepath"].first) && isoptim
-        pg = fix_links(pg)
-    end
-
-    # 5. write the html file where appropriate
-    write(out_path, pg)
+    pg = write_page(output_path, content; head=head, pgfoot=pgfoot, foot=foot,
+                    prerender=prerender, isoptim=isoptim)
 
     # 6. possible post-processing via the "on-write" function.
     on_write(pg, LOCAL_VARS)

--- a/src/manager/write_page.jl
+++ b/src/manager/write_page.jl
@@ -80,6 +80,16 @@ function write_page(output_path::AS, content::AS;
     end
     # convert the pieces
     head, ctt, pgfoot, foot = map(convert_html, (head, content, pgfoot, foot))
+
+    # remove spurious dirs from past pagination attempts
+    outdir = dirname(output_path)
+    for elem in readdir(outdir)
+        if all(isnumeric, elem) && first(elem) != '0'
+            dpath = joinpath(outdir, elem)
+            isdir(dpath) && rm(joinpath(outdir, elem), recursive=true)
+        end
+    end
+
     # the previous call possibly resolved a {{paginate}} which will have
     # stored a :paginate_itr var, so we must branch on that
     if !isnothing(locvar(:paginate_itr))
@@ -88,7 +98,6 @@ function write_page(output_path::AS, content::AS;
         npp     = locvar(:paginate_npp)
         niter   = length(iter)
         n_pages = ceil(Int, niter / npp)
-        outdir  = dirname(output_path)
         for pgi = 1:n_pages
             # form the content multiple times
             sta_i = (pgi - 1) * npp + 1

--- a/src/parser/html/tokens.jl
+++ b/src/parser/html/tokens.jl
@@ -20,9 +20,9 @@ const HTML_TOKENS = LittleDict{Char, Vector{TokenFinder}}(
              isexactly("<script ")  => :SCRIPT_OPEN,
              isexactly("</script>") => :SCRIPT_CLOSE,
             ],
-    '-' => [ isexactly("-->")  => :COMMENT_CLOSE ],  #      ... -->
-    '{' => [ isexactly("{{")   => :H_BLOCK_OPEN  ],  # {{
-    '}' => [ isexactly("}}")   => :H_BLOCK_CLOSE ],  # }}
+    '-' => [ isexactly("-->")    => :COMMENT_CLOSE ],  #      ... -->
+    '{' => [ isexactly("{{")     => :H_BLOCK_OPEN  ],  # {{
+    '}' => [ isexactly("}}")     => :H_BLOCK_CLOSE ],  # }}
     ) # end dict
 
 """

--- a/src/utils/paths.jl
+++ b/src/utils/paths.jl
@@ -95,3 +95,5 @@ with something like `savefig(joinpath(@OUTPUT, "ex1.png"))`.
 macro OUTPUT()
     return OUT_PATH[]
 end
+
+layout_key() = ifelse(FD_ENV[:STRUCTURE] < v"0.2", :src_html, :layout)

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -131,7 +131,7 @@ function def_LOCAL_VARS!()::Nothing
     # Merge global page vars, if it defines anything that local defines, then
     # global takes precedence.
     merge!(LOCAL_VARS, GLOBAL_VARS)
-    # which page we're on, see write_page which sets :CUR_PATH
+    # which page we're on, see convert_and_write which sets :CUR_PATH
     set_var!(LOCAL_VARS, "fd_rpath", FD_ENV[:CUR_PATH])
     set_var!(LOCAL_VARS, "fd_url", url_curpage())
     return nothing
@@ -340,7 +340,7 @@ $(SIGNATURES)
 
 Take a var dictionary `dict` and update the corresponding pair. This should
 only be used internally as it does not check the validity of `val`. See
-[`write_page`](@ref) where it is used to store a file's creation and last
+[`convert_and_write`](@ref) where it is used to store a file's creation and last
 modification time.
 """
 set_var!(d::PageVars, k::K, v) where K = (d[k] = Pair(v, d[k].second); nothing)

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -343,8 +343,14 @@ only be used internally as it does not check the validity of `val`. See
 [`convert_and_write`](@ref) where it is used to store a file's creation and last
 modification time.
 """
-set_var!(d::PageVars, k::K, v) where K = (d[k] = Pair(v, d[k].second); nothing)
-
+function set_var!(d::PageVars, k::K, v) where K
+    if k in keys(d)
+        d[k] = Pair(v, d[k].second)
+    else
+        d[k] = Pair(v, (typeof(v), ))
+    end
+    return
+end
 
 #= =================================================
 set_vars, the key function to assign site variables

--- a/test/manager/paginate.jl
+++ b/test/manager/paginate.jl
@@ -1,0 +1,60 @@
+@testset "Paginate" begin
+    gotd()
+    write(joinpath(td, "config.md"), "")
+    mkpath(joinpath(td, "_css"))
+    mkpath(joinpath(td, "_layout"))
+    write(joinpath(td, "_layout", "head.html"), "HEAD\n")
+    write(joinpath(td, "_layout", "foot.html"), "\nFOOT\n")
+    write(joinpath(td, "_layout", "page_foot.html"), "\nPG_FOOT\n")
+    write(joinpath(td, "index.md"), raw"""
+        @def el = ("a", "b", "c", "d")
+        ~~~<ul>~~~
+        {{paginate el 2}}
+        ~~~</ul>~~~
+        """)
+    write(joinpath(td, "foo.md"), raw"""
+        @def a = ["<li>Item $i</li>" for i in 1:10]
+        Some content
+        ~~~<ul>~~~
+        {{paginate a 4}}
+        ~~~</ul>~~~
+        """)
+    serve(single=true, cleanup=false)
+    # expected outputs for index
+    @test isfile(joinpath("__site", "index.html"))
+    @test isfile(joinpath("__site", "1", "index.html"))
+    @test isfile(joinpath("__site", "2", "index.html"))
+    @test isfile(joinpath("__site", "foo", "index.html"))
+    @test isfile(joinpath("__site", "foo", "1", "index.html"))
+    @test isfile(joinpath("__site", "foo", "2", "index.html"))
+    @test isfile(joinpath("__site", "foo", "3", "index.html"))
+    # expected content
+    @test read(joinpath("__site", "index.html"), String) // """
+        HEAD
+        <div class=\"franklin-content\"><p><ul> ab </ul></p>
+
+        PG_FOOT
+        </div>
+        FOOT"""
+    @test read(joinpath("__site", "2", "index.html"), String) // """
+        HEAD
+        <div class=\"franklin-content\"><p><ul> cd </ul></p>
+
+        PG_FOOT
+        </div>
+        FOOT"""
+    @test read(joinpath("__site", "foo", "1", "index.html"), String) // """
+        HEAD
+        <div class=\"franklin-content\"><p>Some content <ul> <li>Item 1</li><li>Item 2</li><li>Item 3</li><li>Item 4</li> </ul></p>
+
+        PG_FOOT
+        </div>
+        FOOT"""
+    @test read(joinpath("__site", "foo", "3", "index.html"), String) // """
+        HEAD
+        <div class=\"franklin-content\"><p>Some content <ul> <li>Item 9</li><li>Item 10</li> </ul></p>
+
+        PG_FOOT
+        </div>
+        FOOT"""
+end

--- a/test/manager/utils.jl
+++ b/test/manager/utils.jl
@@ -62,7 +62,7 @@ end
     foot = "foot {{fill author}}"
 
     out_file = F.form_output_path(F.PATHS[:folder], "index.html", :html)
-    F.write_page(F.PATHS[:src], "index.md", head, pg_foot, foot, out_file)
+    F.convert_and_write(F.PATHS[:src], "index.md", head, pg_foot, foot, out_file)
 
     @test isfile(out_file)
     @test isapproxstr(read(out_file, String), """

--- a/test/manager/utils_fs2.jl
+++ b/test/manager/utils_fs2.jl
@@ -63,7 +63,7 @@ end
     foot = "foot {{fill author}}"
 
     out_file = F.form_output_path(F.PATHS[:site], "index.html", :html)
-    F.write_page(F.PATHS[:folder], "index.md", head, pg_foot, foot, out_file)
+    F.convert_and_write(F.PATHS[:folder], "index.md", head, pg_foot, foot, out_file)
 
     @test isfile(out_file)
     @test isapproxstr(read(out_file, String), """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,7 +130,7 @@ include("coverage/extras1.jl")
 include("coverage/paths.jl")
 
 println("😅 😅 😅 😅")
-
+s
 # check quickly if the IPs in IP_CHECK are still ok
 println("Verifying ip addresses, if online these should succeed.")
 for (addr, name) in F.IP_CHECK

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,8 @@ F.FD_ENV[:SILENT_MODE] = true
 # F.FD_ENV[:DEBUG_MODE] = true
 F.FD_ENV[:STRUCTURE] = v"0.1" # legacy, it's switched up in the tests.
 
+Franklin.FD_ENV[:QUIET_TEST] = true
+
 # UTILS
 println("UTILS-1")
 include("utils/folder_structure.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,7 @@ include("manager/config.jl")
 include("manager/config_fs2.jl")
 include("manager/dir_utils.jl")
 include("manager/page_vars_html.jl")
+include("manager/paginate.jl")
 println("🍺")
 
 # PARSER folder


### PR DESCRIPTION
Oh gosh finally... 

Support for pagination, works like:

```
@def some_list = ["<li>$lc</li>" for lc in ("Stefan", "Jeff", "Alan", "Viral")]
~~~<ul>~~~
{{paginate some_list 2}}
~~~</ul>~~~
```

Assuming this is on page `foo.md` it will lead to

* `/foo/` and `/foo/1/` with content `<li>Stefan</li><li>Jeff</li>`
* `/foo/2/` with content `<li>Alan</li><li>Viral</li>`

**Note**: this can be used with any sort of list or item, so it doesn't necessarily need to be a `<li>...` in fact it could be div blocks. More specific functionality can be wrapped in a newcommand e.g.:

```
\newcommand{\paginated_list}[2]{~~~<ul>~~~{{paginate #1 #2}}~~~</ul>~~~}
```

(will be a demo in FranklinFAQ)

closes #496 

**Note**: if pagination over 5 pages then changing something and paginating over 2 pages, the dirs 3,4,5 will be removed. This should generally be innocuous with the exception of people who want to paginate their front page in which case it may be more likely to have numeric dirs in `__site` (but not very so probably still fine). 