### PR TITLE
support for +++...+++ blocks, closes #587

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.9.4"
+version = "0.9.5"
 
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"

--- a/src/converter/markdown/md.jl
+++ b/src/converter/markdown/md.jl
@@ -44,10 +44,10 @@ function convert_md(mds::AbstractString,
     tokens = find_tokens(mds, MD_TOKENS, MD_1C_TOKENS)
     (:convert_md, "convert_md: '$([t.name for t in tokens])'") |> logger
 
+    # validate toml open/close
+    validate_start_of_line!(tokens, (:MD_DEF_TOML, MD_HEADER_OPEN...))
     # distinguish fnref/fndef
     validate_footnotes!(tokens)
-    # ignore header tokens that are not at the start of a line
-    validate_headers!(tokens)
     # validate emojis
     validate_emojis!(tokens)
     # capture some hrule (see issue #432)

--- a/src/converter/markdown/mddefs.jl
+++ b/src/converter/markdown/mddefs.jl
@@ -29,6 +29,7 @@ function process_mddefs(blocks::Vector{OCBlock}, isconfig::Bool,
         end
         # get the variable names (from all assignments)
         vnames = [ex.args[1] for ex in exs if ex.head == :(=)]
+        filter!(v -> v isa Symbol, vnames)
         for vname in vnames
             key    = String(vname)
             value  = getproperty(mdl, vname)

--- a/src/parser/markdown/tokens.jl
+++ b/src/parser/markdown/tokens.jl
@@ -32,7 +32,7 @@ that works will be taken.
 const MD_TOKENS = LittleDict{Char, Vector{TokenFinder}}(
     '<'  => [ isexactly("<!--")  => :COMMENT_OPEN,     # <!-- ...
              ],
-    '+'  => [ isexactly("+++")   => :MD_DEF_TOML,
+    '+'  => [ isexactly("+++", ('\n',)) => :MD_DEF_TOML,
              ],
     '-'  => [ isexactly("-->")   => :COMMENT_CLOSE,    #  ... -->
               incrlook(is_hr1)   => :HORIZONTAL_RULE,  # ---+

--- a/src/parser/markdown/tokens.jl
+++ b/src/parser/markdown/tokens.jl
@@ -21,6 +21,7 @@ const MD_1C_TOKENS_LX = LittleDict{Char, Symbol}(
     '}'  => :LXB_CLOSE
     )
 
+
 """
     MD_TOKENS
 
@@ -30,6 +31,8 @@ that works will be taken.
 """
 const MD_TOKENS = LittleDict{Char, Vector{TokenFinder}}(
     '<'  => [ isexactly("<!--")  => :COMMENT_OPEN,     # <!-- ...
+             ],
+    '+'  => [ isexactly("+++")   => :MD_DEF_TOML,
              ],
     '-'  => [ isexactly("-->")   => :COMMENT_CLOSE,    #  ... -->
               incrlook(is_hr1)   => :HORIZONTAL_RULE,  # ---+
@@ -136,9 +139,10 @@ not deactivate its content which is needed to find latex definitions
 (see parser/markdown/find_blocks/find_lxdefs).
 """
 const MD_OCB = [
-    # name                    opening token   closing token(s)  nestable
+    # name                    opening token   closing token(s)
     # ---------------------------------------------------------------------
     OCProto(:COMMENT,         :COMMENT_OPEN, (:COMMENT_CLOSE,)),
+    OCProto(:MD_DEF_BLOCK,    :MD_DEF_TOML,  (:MD_DEF_TOML,)  ),
     OCProto(:CODE_BLOCK_LANG, :CODE_LANG,    (:CODE_TRIPLE,)  ),
     OCProto(:CODE_BLOCK_LANG, :CODE_LANG2,   (:CODE_PENTA,)   ),
     OCProto(:CODE_BLOCK,      :CODE_TRIPLE,  (:CODE_TRIPLE,)  ),

--- a/src/parser/markdown/validate.jl
+++ b/src/parser/markdown/validate.jl
@@ -1,4 +1,29 @@
 """
+$(SIGNATURES)
+
+Given a candidate header block, check that the opening `#` is at the start of a
+line, otherwise ignore the block.
+"""
+function validate_start_of_line!(tokens::Vector{Token}, names)::Nothing
+    isempty(tokens) && return
+    s = str(tokens[1].ss) # does not allocate
+    rm = Int[]
+    for (i, τ) in enumerate(tokens)
+        τ.name in names || continue
+        # check if it overlaps with the first character
+        fromτ = from(τ)
+        fromτ == 1 && continue
+        # otherwise check if the previous character is a linereturn
+        prevc = s[prevind(s, fromτ)]
+        prevc == '\n' && continue
+        push!(rm, i)
+    end
+    deleteat!(tokens, rm)
+    return
+end
+
+
+"""
 $SIGNATURES
 
 Find footnotes refs and defs and eliminate the ones that don't verify the
@@ -33,30 +58,6 @@ $SIGNATURES
 Verify that a given string corresponds to a well formed html entity.
 """
 validate_html_entity(ss::AS) = !isnothing(match(HTML_ENT_PAT, ss))
-
-"""
-$(SIGNATURES)
-
-Given a candidate header block, check that the opening `#` is at the start of a
-line, otherwise ignore the block.
-"""
-function validate_headers!(tokens::Vector{Token})::Nothing
-    isempty(tokens) && return
-    s = str(tokens[1].ss) # does not allocate
-    rm = Int[]
-    for (i, τ) in enumerate(tokens)
-        τ.name in MD_HEADER_OPEN || continue
-        # check if it overlaps with the first character
-        fromτ = from(τ)
-        fromτ == 1 && continue
-        # otherwise check if the previous character is a linereturn
-        prevc = s[prevind(s, fromτ)]
-        prevc == '\n' && continue
-        push!(rm, i)
-    end
-    deleteat!(tokens, rm)
-    return
-end
 
 
 function validate_emojis!(tokens::Vector{Token})::Nothing

--- a/test/converter/md/md_defs2.jl
+++ b/test/converter/md/md_defs2.jl
@@ -65,6 +65,15 @@ end
         +++
         {{a}}
         """ |> fd2html
+    # more things
+    s = """
+       +++
+       foo(x, y, z) = x^2 + 2y + z
+       out = foo(2,3,4)
+       +++
+       {{out}}
+       """ |> fd2html
+    @test isapproxstr(s, "<p>14</p>")
     @test isapproxstr(s, "<p>hello 7 7</p>")
     # errors
     s = """

--- a/test/converter/md/md_defs2.jl
+++ b/test/converter/md/md_defs2.jl
@@ -65,6 +65,7 @@ end
         +++
         {{a}}
         """ |> fd2html
+    @test isapproxstr(s, "<p>hello 7 7</p>")
     # more things
     s = """
        +++
@@ -74,7 +75,6 @@ end
        {{out}}
        """ |> fd2html
     @test isapproxstr(s, "<p>14</p>")
-    @test isapproxstr(s, "<p>hello 7 7</p>")
     # errors
     s = """
         +++

--- a/test/converter/md/md_defs2.jl
+++ b/test/converter/md/md_defs2.jl
@@ -42,3 +42,36 @@
     @test occursin(
         "<code class=\"plaintext\">2</code>", h)
 end
+
+# Blocks of definitions
+@testset "mddefblock" begin
+    s = """
+        +++
+        a = 5
+        b = "hello"
+        +++
+        {{b}} {{a}}
+        """ |> fd2html
+    # danger of the stuff
+    @test isapproxstr(s, "<p>hello 5</p>")
+    s = """
+        +++
+        a = 5
+        b = "hello"
+        +++
+        {{b}} {{a}}
+        +++
+        a = 7
+        +++
+        {{a}}
+        """ |> fd2html
+    @test isapproxstr(s, "<p>hello 7 7</p>")
+    # errors
+    s = """
+        +++
+        s = sqrt(-1)
+        +++
+        {{s}}
+        """
+    @test_throws ErrorException s |> fd2html
+end

--- a/test/parser/1-tokenize.jl
+++ b/test/parser/1-tokenize.jl
@@ -1,6 +1,6 @@
 tok  = s -> F.find_tokens(s, F.MD_TOKENS, F.MD_1C_TOKENS)
 vfn  = s -> (t = tok(s); F.validate_footnotes!(t); t)
-vh   = s -> (t = vfn(s); F.validate_headers!(t); t)
+vh   = s -> (t = vfn(s); F.validate_start_of_line!(t, Franklin.MD_HEADER_OPEN); t)
 fib  = s -> (t = vh(s); F.find_indented_blocks!(t, s); t)
 fib2 = s -> (t = fib(s); F.filter_lr_indent!(t, s); t)
 

--- a/test/parser/2-blocks.jl
+++ b/test/parser/2-blocks.jl
@@ -1,6 +1,6 @@
 tok  = s -> F.find_tokens(s, F.MD_TOKENS, F.MD_1C_TOKENS)
 vfn  = s -> (t = tok(s); F.validate_footnotes!(t); t)
-vh   = s -> (t = vfn(s); F.validate_headers!(t); t)
+vh   = s -> (t = vfn(s); F.validate_start_of_line!(t, Franklin.MD_HEADER_OPEN); t)
 fib  = s -> (t = vh(s); F.find_indented_blocks!(t, s); t)
 fib2 = s -> (t = fib(s); F.filter_lr_indent!(t, s); t)
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -64,7 +64,7 @@ function explore_md_steps(mds)
     # tokenize
     tokens = F.find_tokens(mds, F.MD_TOKENS, F.MD_1C_TOKENS)
     F.validate_footnotes!(tokens)
-    F.validate_headers!(tokens)
+    F.validate_start_of_line!(tokens, F.MD_HEADER_OPEN)
     hrules = F.find_hrules!(tokens)
     F.find_indented_blocks!(tokens, mds)
     steps[:tokenization] = (tokens=tokens,)


### PR DESCRIPTION
This is now allowed:

```
+++
a = 5
b = "hello"
+++
{{b}} {{a}}
```

(will show `hello 5`)

and can be used instead of

```
@def a = 5
@def b = "hello"
{{b}} {{a}}
```

**Note**: what's in the `+++...+++` block is executed as raw Julia code and the assignments are then passed to GLOBAL_VARS or LOCAL_VARS depending on whether we're on `config.md` or not. This means that you could write arbitrary code and save the output in a var which is then accessible for instance:

```
+++
foo(x, y, z) = x^2 + 2y + z
out = foo(2,3,4)
+++
{{out}}
```

will show `14`. 

(if you want to show the code you should use evaluated code blocks as per usual though)