### PR TITLE
bug fix with pagination cleanup

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.9.9"
+version = "0.9.10"
 
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"


### PR DESCRIPTION
This addresses the issue https://github.com/JuliaLang/www.julialang.org/issues/969 the cleanup function for spurious paginated folder was too aggressive and ended up cleaning up valid folders instead of just the paginated ones. 