### PR TITLE
fix for +++ blocks and launch_browser option

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.10.0"
+version = "0.10.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/converter/markdown/mddefs.jl
+++ b/src/converter/markdown/mddefs.jl
@@ -20,7 +20,7 @@ function process_mddefs(blocks::Vector{OCBlock}, isconfig::Bool,
     for mdb in filter(β -> (β.name == :MD_DEF_BLOCK), blocks)
         inner = stent(mdb)
         exs = parse_code(inner)
-        mdl = Module()
+        mdl = newmodule("MD_DEFINITIONS")
         try
             foreach(ex -> Core.eval(mdl, ex), exs)
         catch

--- a/src/eval/module.jl
+++ b/src/eval/module.jl
@@ -39,10 +39,11 @@ function newmodule(name::String)::Module
                     import Franklin
                     import Franklin: @OUTPUT, @delay, fdplotly,
                                      locvar, pagevar, globvar,
-                                     fd2html, get_url 
+                                     fd2html, get_url
                     if isdefined(Main, :Utils) && typeof(Main.Utils) == Module
                         import ..Utils
                     end
+                    using Dates
                 end
                 """))
         end

--- a/src/manager/franklin.jl
+++ b/src/manager/franklin.jl
@@ -43,7 +43,8 @@ Keyword arguments:
                       passing as arguments the rendered page and the page
                       variables
 * `host="127.0.0.1"`: the host to use for the local server
-* `show_warnings`:    whether to show franklin  warnings
+* `show_warnings=true`: whether to show franklin  warnings
+* `launch=!single`:   whether to launch the browser when serving
 """
 function serve(; clear::Bool=false,
                  verb::Bool=false,
@@ -59,7 +60,8 @@ function serve(; clear::Bool=false,
                  on_write::Function=(_, _) -> nothing,
                  log::Bool=false,
                  host::String="127.0.0.1",
-                 show_warnings::Bool=true
+                 show_warnings::Bool=true,
+                 launch::Bool=!single,
                  )::Union{Nothing,Int}
     LOGGING[] = log
     # set the global path
@@ -130,7 +132,7 @@ function serve(; clear::Bool=false,
         live_server_dir = "__site"
         LiveServer.setverbose(verb)
         LiveServer.serve(port=port, coreloopfun=coreloopfun,
-                         dir=live_server_dir, host=host)
+                         dir=live_server_dir, host=host, launch_browser=launch)
     end
     flag_env &&
         rprint("→ Use Pkg.activate() to go back to your main environment.")

--- a/test/converter/md/md_defs2.jl
+++ b/test/converter/md/md_defs2.jl
@@ -84,3 +84,15 @@ end
         """
     @test_throws ErrorException s |> fd2html
 end
+
+# blocks of definition with date
+@testset "mddefblock+date" begin
+    s = """
+        +++
+        a = 5
+        pubdate = Date(2013, 9, 4)
+        +++
+        {{a}} {{pubdate}}
+        """ |> fd2html
+    @test isapproxstr(s, "<p> 5 2013-09-04</p>")
+end


### PR DESCRIPTION
Thanks to Roger Luo, we now have the browser launching automatically when serving (you can turn that off with `serve(launch=false)`. 