### PR TITLE
Minor fixes + sitemap generation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.10.1"
+version = "0.10.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Franklin.jl
+++ b/src/Franklin.jl
@@ -86,8 +86,9 @@ const FD_ENV = LittleDict(
     :SHOW_WARNINGS => true,     # franklin-specific warnings
     )
 
-# keep track of pages which need to be re-evaluated after the full-pass to ensure that
-# their h-fun are working with the fully-defined scope (e.g. if need tags)
+# keep track of pages which need to be re-evaluated after the full-pass
+# to ensure that their h-fun are working with the fully-defined scope
+# (e.g. if need list of all tags)
 const DELAYED = Set{String}()
 
 """Dict to keep track of languages and how comments are indicated and their extensions. This is relevant to allow hiding lines of code. """
@@ -203,6 +204,7 @@ include("converter/html/prerender.jl")
 
 # FILE AND DIR MANAGEMENT
 include("manager/rss_generator.jl")
+include("manager/sitemap_generator.jl")
 include("manager/write_page.jl")
 include("manager/dir_utils.jl")
 include("manager/file_utils.jl")

--- a/src/converter/markdown/blocks.jl
+++ b/src/converter/markdown/blocks.jl
@@ -118,7 +118,7 @@ function convert_header(β::OCBlock, lxdefs::Vector{LxDef})::String
     hk    = lowercase(string(β.name)) # h1, h2, ...
     title = convert_md(content(β), lxdefs;
                        isrecursive=true, has_mddefs=false)
-    rstitle = refstring(title)
+    rstitle = refstring(html_unescape(title))
     # check if the header has appeared before and if so suggest
     # an altered refstring; if that altered refstring also exist
     # (pathological case, see #241), then extend it with a letter

--- a/src/converter/markdown/mddefs.jl
+++ b/src/converter/markdown/mddefs.jl
@@ -72,7 +72,7 @@ function process_mddefs(blocks::Vector{OCBlock}, isconfig::Bool,
     # if in config file, update `GLOBAL_VARS` and return
     rpath = splitext(locvar(:fd_rpath))[1]
     if isconfig
-        set_vars!(GLOBAL_VARS, assignments)
+        set_vars!(GLOBAL_VARS, assignments, isglobal=true)
         return nothing
     end
 

--- a/src/eval/codeblock.jl
+++ b/src/eval/codeblock.jl
@@ -36,6 +36,9 @@ The code should be reevaluated if any of following flags are true:
 1. the output is missings
 """
 function should_eval(code::AS, rpath::AS)
+    # 0. the page is currently delayed, skip evals
+    FD_ENV[:SOURCE] in DELAYED && return false
+    
     # 1. global setting forcing all pages to reeval
     FD_ENV[:FORCE_REEVAL] && return true
 

--- a/src/manager/file_utils.jl
+++ b/src/manager/file_utils.jl
@@ -8,28 +8,13 @@ The keyword `init` is used internally to distinguish between the first call
 where only structural variables are considered (e.g. controlling folder
 structure).
 """
-function process_config(; init::Bool=false)::Nothing
+function process_config()::Nothing
     FD_ENV[:SOURCE] = "config.md"
-    if init
-        # initially the paths variable aren't set, try to find a config.md
-        # and read definitions in it; in particular folder_structure.
-        config_path_v1 = joinpath(FOLDER_PATH[], "src", "config.md")
-        config_path_v2 = joinpath(FOLDER_PATH[], "config.md")
-        if isfile(config_path_v2)
-            convert_md(read(config_path_v2, String); isconfig=true)
-        elseif isfile(config_path_v1)
-            convert_md(read(config_path_v1, String); isconfig=true)
-        else
-            config_warn()
-        end
+    config_path = joinpath(FOLDER_PATH[], "config.md")
+    if isfile(config_path)
+        convert_md(read(config_path, String); isconfig=true)
     else
-        dir = path(:folder)
-        config_path = joinpath(dir, "config.md")
-        if isfile(config_path)
-            convert_md(read(config_path, String); isconfig=true)
-        else
-            config_warn()
-        end
+        config_warn()
     end
     return nothing
 end
@@ -45,15 +30,8 @@ recommended.
 """
 function process_utils()
     FD_ENV[:SOURCE] = "utils.jl"
-    utils_path_v1 = joinpath(FOLDER_PATH[], "src", "utils.jl")
-    utils_path_v2 = joinpath(FOLDER_PATH[], "utils.jl")
-    if isfile(utils_path_v2)
-        utils = utils_path_v2
-    elseif isfile(utils_path_v1)
-        utils = utils_path_v1
-    else
-        return nothing
-    end
+    utils = joinpath(FOLDER_PATH[], "utils.jl")
+    isfile(utils) || return nothing
     # wipe / create module Utils
     newmodule("Utils")
     Base.include(Main.Utils, utils)

--- a/src/manager/file_utils.jl
+++ b/src/manager/file_utils.jl
@@ -100,6 +100,10 @@ function process_file_err(case::Symbol, fpair::Pair{String, String},
         set_cur_rpath(joinpath(fpair...))
         set_page_env()
         raw_html  = read(inp, String)
+        # add the item *before* the conversion so that the conversion
+        # can affect the page itself with {{...}}
+        cond_add = globvar(:generate_sitemap) && FD_ENV[:FULL_PASS]
+        cond_add && add_sitemap_item(html=true)
         proc_html = convert_html(raw_html) |> postprocess_page
         write(outp, proc_html)
     else # case in (:other, :infra)

--- a/src/manager/franklin.jl
+++ b/src/manager/franklin.jl
@@ -202,7 +202,7 @@ function fd_fullpass(watched_files::NamedTuple)::Int
     prepath = get(GLOBAL_VARS, "prepath", "")
     def_GLOBAL_VARS!()
     def_GLOBAL_LXDEFS!()
-    empty!(RSS_DICT)
+    empty!.((RSS_DICT, SITEMAP_DICT))
     # reinsert prepath if specified
     isempty(prepath) || (GLOBAL_VARS["prepath"] = prepath)
 
@@ -268,6 +268,8 @@ function fd_fullpass(watched_files::NamedTuple)::Int
     globvar("generate_rss") && rss_generator()
     # generate tags if appropriate
     generate_tag_pages()
+    # generate sitemap if appropriate
+    globvar("generate_sitemap") && sitemap_generator()
     # done
     FD_ENV[:FULL_PASS] = false
     # return -1 if any page failed to build, 0 otherwise

--- a/src/manager/franklin.jl
+++ b/src/manager/franklin.jl
@@ -89,7 +89,7 @@ function serve(; clear::Bool=false,
 
     # check if there's a config file, if there is, check the variable
     # definitions looking at the ones that would affect overall structure etc.
-    process_config(init=true)
+    process_config()
 
     if !all(isdir, (joinpath(FOLDER_PATH[], "_layout"),
                     joinpath(FOLDER_PATH[], "_css")))

--- a/src/manager/rss_generator.jl
+++ b/src/manager/rss_generator.jl
@@ -59,7 +59,7 @@ $SIGNATURES
 
 Create an `RSSItem` out of the provided fields defined in the page vars.
 """
-function add_rss_item()::RSSItem
+function add_rss_item()
     link  = url_curpage()
     title = jor("rss_title", "title")
     descr = jor("rss", "rss_description")
@@ -85,8 +85,9 @@ function add_rss_item()::RSSItem
         An RSS description was found but without title for page '$link'.
         """)
 
-    RSS_DICT[link] = RSSItem(title, link, descr, author,
-                             category, comments, enclosure, pubDate)
+    res = RSS_DICT[link] = RSSItem(title, link, descr, author,
+                                   category, comments, enclosure, pubDate)
+    return res
 end
 
 

--- a/src/manager/sitemap_generator.jl
+++ b/src/manager/sitemap_generator.jl
@@ -1,0 +1,95 @@
+# <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+# <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+# <url>
+#      <loc>http://www.example.com/</loc>
+#      ?<lastmod>2005-01-01</lastmod>
+#      ?<changefreq>monthly</changefreq>
+#      ?<priority>0.8</priority>
+# </url>
+# </urlset>
+#
+# TODO
+# allow {{sitemap_exclude}} for a HTML page to avoid having it in sitemap
+#
+
+struct SMOpts
+    lastmod::Date        # 2005-01-01 -- format YYYY-MM-DD
+    changefreq::String   # one of...
+    priority::Float64    #
+    function SMOpts(l, c, p)
+        c = lowercase(c)
+        allowedf = ("always", "hourly", "daily", "weekly", "monthly",
+        "yearly", "never")
+        assertf = """
+        Given change frequency on $(FD_ENV[:SOURCE]) is invalid according to
+        sitemap specifications, expected one of $allowedf.
+        """
+        assertp = """
+        Given priority on $(FD_ENV[:SOURCE]) is invalid according to sitemap
+        specifications, expected a floating point number between 0 and 1.
+        """
+        @assert c in allowedf assertf
+        @assert 0 <= p <= 1 assertp
+        return new(l, c, p)
+    end
+end
+
+const SITEMAP_DICT = LittleDict{String,SMOpts}()
+
+"""
+$SIGNATURES
+
+Add an entry to `SITEMAP_DICT`.
+"""
+function add_sitemap_item(; html=false)
+    loc = url_curpage()
+    locvar(:sitemap_exclude) && return nothing
+    if !html
+        lastmod = locvar(:fd_mtime)
+        changefreq = locvar(:sitemap_changefreq)
+        priority = locvar(:sitemap_priority)
+    else
+        # use default which can be overwritten in a {{sitemap_opts ...}}
+        fp = joinpath(path(:folder), locvar(:fd_rpath))
+        lastmod = Date(unix2datetime(stat(fp).mtime))
+        changefreq = "monthly"
+        priority = 0.5
+    end
+    res = SITEMAP_DICT[loc] = SMOpts(lastmod, changefreq, priority)
+    return res
+end
+
+"""
+$SIGNATURES
+
+Generate a `sitemap.xml`, if one already exists, it will be replaced.
+"""
+function sitemap_generator()
+    dst = joinpath(path(:site), "sitemap.xml")
+    isfile(dst) && rm(dst)
+    io = IOBuffer()
+    println(io, """
+        <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+        """)
+    base_url = globvar(:website_url)
+    for (k, v) in SITEMAP_DICT
+        key = joinpath(escapeuri.(split(k, '/'))...)
+        loc = "<loc>$(joinpath(base_url, key))</loc>"
+        lastmod = ifelse(v.lastmod > Date(1),
+                         "<lastmod>$(v.lastmod)</lastmod>", "")
+        changefreq = "<changefreq>$(v.changefreq)</changefreq>"
+        priority = "<priority>$(v.priority)</priority>"
+        write(io, """
+            <url>
+                $loc
+                $lastmod
+                $changefreq
+                $priority
+            </url>
+            """)
+    end
+    println(io, "</urlset>")
+    write(dst, take!(io))
+    return nothing
+end

--- a/src/manager/write_page.jl
+++ b/src/manager/write_page.jl
@@ -162,11 +162,15 @@ function convert_and_write(root::String, file::String, head::String,
     #   should we generate ? otherwise no
     #   are we in the full pass ? otherwise no
     #   is there a `rss` or `rss_description` ? otherwise no
-    cond_add = GLOBAL_VARS["generate_rss"].first &&  # should we generate?
-                    FD_ENV[:FULL_PASS] &&            # are we in the full pass?
+    cond_add = globvar(:generate_rss) &&   # should we generate?
+                    FD_ENV[:FULL_PASS] &&  # are we in the full pass?
                     !all(e -> isempty(locvar(e)), ("rss", "rss_description"))
     # otherwise yes
     cond_add && add_rss_item()
+
+    # Same for the sitemap
+    cond_add = globvar(:generate_sitemap) && FD_ENV[:FULL_PASS]
+    cond_add && add_sitemap_item()
 
     # adding document variables to the dictionary
     # note that some won't change and so it's not necessary to do this every

--- a/src/utils/misc.jl
+++ b/src/utils/misc.jl
@@ -266,3 +266,17 @@ macro delay(defun)
     end
     esc(combinedef(def))
 end
+
+# URI encoding stolen from HTTP.jl (+ simplified)
+
+# RFC3986 Unreserved Characters (and '~' Unsafe per RFC1738).
+issafe(c::Char) = c == '-' ||
+                  c == '.' ||
+                  c == '_' ||
+                  (isascii(c) && (isletter(c) || isnumeric(c)))
+
+utf8(s::AS) = (Char(c) for c in codeunits(s))
+
+escapeuri(c::Char) = string('%', uppercase(string(Int(c), base=16, pad=2)))
+escapeuri(str::AS) =
+    join(ifelse(issafe(c), c, escapeuri(Char(c))) for c in utf8(str))

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -2,6 +2,15 @@ const DTAG  = LittleDict{String,Set{String}}
 const DTAGI = LittleDict{String,Vector{String}}
 
 """
+    dpair
+
+Helper function to create a default pair for a page variable.
+"""
+dpair(v) = Pair(v, (typeof(v),))
+
+"""
+    GLOBAL_VARS
+
 Dictionary of variables accessible to all pages. Used as an initialiser for
 `LOCAL_VARS` and modified by `config.md`.
 Entries have the format KEY => PAIR where KEY is a string (e.g.: "author") and
@@ -14,34 +23,41 @@ const GLOBAL_VARS = PageVars()
 const GLOBAL_VARS_DEFAULT = [
     # General
     "author"           => Pair("THE AUTHOR", (String, Nothing)),
-    "date_format"      => Pair("U dd, yyyy", (String,)),
-    "date_months"      => Pair(String[],     (Vector{String},)),
-    "date_shortmonths" => Pair(String[],     (Vector{String},)),
-    "date_days"        => Pair(String[],     (Vector{String},)),
-    "date_shortdays"   => Pair(String[],     (Vector{String},)),
-    "prepath"          => Pair("",           (String,)),
-    "tag_page_path"    => Pair("tag", (String,)),
+    "date_format"      => dpair("U dd, yyyy"),
+    "date_months"      => dpair(String[]),
+    "date_shortmonths" => dpair(String[]),
+    "date_days"        => dpair(String[]),
+    "date_shortdays"   => dpair(String[]),
+    "prepath"          => dpair(""),
+    "tag_page_path"    => dpair("tag"),
     # will be added to IGNORE_FILES
     "ignore"           => Pair(String[], (Vector{Any},)),
-    # RSS
-    "website_title"    => Pair("",   (String,)),
-    "website_descr"    => Pair("",   (String,)),
-    "website_url"      => Pair("",   (String,)),
-    "generate_rss"     => Pair(true, (Bool,)),
+    # RSS + sitemap
+    "website_title"    => dpair(""),
+    "website_descr"    => dpair(""),
+    "website_url"      => dpair(""),
+    "generate_rss"     => dpair(true),
+    "generate_sitemap" => dpair(true),
     # div names
-    "content_tag"      => Pair("div",              (String,)),
-    "content_class"    => Pair("franklin-content", (String,)),
-    "content_id"       => Pair("",                 (String,)),
+    "content_tag"      => dpair("div"),
+    "content_class"    => dpair("franklin-content"),
+    "content_id"       => dpair(""),
     # auto detection of code / math (see hasmath/hascode)
-    "autocode"         => Pair(true, (Bool,)),
-    "automath"         => Pair(true, (Bool,)),
+    "autocode"         => dpair(true),
+    "automath"         => dpair(true),
     # keep track page=>tags and tag=>pages
     "fd_page_tags"     => Pair(nothing, (DTAG,  Nothing)),
     "fd_tag_pages"     => Pair(nothing, (DTAGI, Nothing)),
     # -----------------------------------------------------
     # LEGACY
-    "div_content" => Pair("", (String,)), # see build_page
+    "div_content" => dpair(""), # see build_page
     ]
+
+const GLOBAL_VARS_ALIASES = LittleDict(
+    "prefix"    => "prepath",
+    "base_path" => "prepath",
+    "base_url"  => "website_url",
+    )
 
 """
 Re-initialise the global page vars dictionary. (This is done once).
@@ -63,40 +79,45 @@ const LOCAL_VARS = PageVars()
 const LOCAL_VARS_DEFAULT = [
     # General
     "title"         => Pair(nothing,    (String, Nothing)),
-    "hasmath"       => Pair(false,      (Bool,)),
-    "hascode"       => Pair(false,      (Bool,)),
+    "hasmath"       => dpair(false),
+    "hascode"       => dpair(false),
     "date"          => Pair(Date(1),    (String, Date, Nothing)),
-    "lang"          => Pair("julia",    (String,)), # default lang indented code
-    "reflinks"      => Pair(true,       (Bool,)),   # are there reflinks?
-    "indented_code" => Pair(false,      (Bool,)),   # support indented code?
-    "tags"          => Pair(String[],   (Vector{String},)),
-    "prerender"     => Pair(true,       (Bool,)),   # allow specific switch
+    "lang"          => dpair("julia"),  # default lang indented code
+    "reflinks"      => dpair(true),     # are there reflinks?
+    "indented_code" => dpair(false),    # support indented code?
+    "tags"          => dpair(String[]),
+    "prerender"     => dpair(true),     # allow specific switch
     # -----------------
     # TABLE OF CONTENTS
-    "mintoclevel" => Pair(1,  (Int,)), # set to 2 to ignore h1
-    "maxtoclevel" => Pair(10, (Int,)), # set to 3 to ignore h4,h5,h6
+    "mintoclevel" => dpair(1),   # set to 2 to ignore h1
+    "maxtoclevel" => dpair(10),  # set to 3 to ignore h4,h5,h6
     # ---------------
     # CODE EVALUATION
-    "reeval"        => Pair(false,  (Bool,)), # whether to reeval all pg
-    "showall"       => Pair(false,  (Bool,)), # if true, notebook style
-    "fd_eval"       => Pair(false,  (Bool,)), # toggle re-eval
+    "reeval"        => dpair(false),  # whether to reeval all pg
+    "showall"       => dpair(false),  # if true, notebook style
+    "fd_eval"       => dpair(false),  # toggle re-eval
     # ------------------
     # RSS 2.0 specs [^2]
-    "rss"             => Pair("",      (String,)),
-    "rss_description" => Pair("",      (String,)),
-    "rss_title"       => Pair("",      (String,)),
-    "rss_author"      => Pair("",      (String,)),
-    "rss_category"    => Pair("",      (String,)),
-    "rss_comments"    => Pair("",      (String,)),
-    "rss_enclosure"   => Pair("",      (String,)),
-    "rss_pubdate"     => Pair(Date(1), (Date,)),
+    "rss"             => dpair(""),
+    "rss_description" => dpair(""),
+    "rss_title"       => dpair(""),
+    "rss_author"      => dpair(""),
+    "rss_category"    => dpair(""),
+    "rss_comments"    => dpair(""),
+    "rss_enclosure"   => dpair(""),
+    "rss_pubdate"     => dpair(Date(1)),
+    # -------------
+    # SITEMAP specs https://www.sitemaps.org/protocol.html
+    "sitemap_changefreq" => dpair("monthly"),
+    "sitemap_priority"   => dpair(0.5),
+    "sitemap_exclude"    => dpair(false),
     # -------------
     # MISCELLANEOUS (should not be modified)
-    "fd_ctime"  => Pair(Date(1),    (Date,)),   # time of creation
-    "fd_mtime"  => Pair(Date(1),    (Date,)),   # time of last modification
-    "fd_rpath"  => Pair("",         (String,)), # rpath to current page [1]
-    "fd_url"    => Pair("",         (String,)), # url to current page [2]
-    "fd_tag"    => Pair("",         (String,)), # (generated) current tag
+    "fd_ctime"  => dpair(Date(1)),  # time of creation
+    "fd_mtime"  => dpair(Date(1)),  # time of last modification
+    "fd_rpath"  => dpair(""),       # rpath to current page [1]
+    "fd_url"    => dpair(""),       # url to current page [2]
+    "fd_tag"    => dpair(""),       # (generated) current tag
     ]
 #=
 NOTE:
@@ -363,8 +384,8 @@ The entries in `assignments` are of the form `KEY => STR` where `KEY` is a
 string key (e.g.: "hasmath") and `STR` is an assignment to evaluate (e.g.:
 "=false").
 """
-function set_vars!(vars::PageVars, assignments::Vector{Pair{String,String}}
-                   )::PageVars
+function set_vars!(vars::PageVars, assignments::Vector{Pair{String,String}}; 
+                   isglobal=false)::PageVars
     # if there's no assignment, cut it short
     isempty(assignments) && return vars
     # process each assignment in turn
@@ -385,7 +406,13 @@ function set_vars!(vars::PageVars, assignments::Vector{Pair{String,String}}
                 "An error (of type '$(typeof(err))') occurred when trying " *
                 "to evaluate '$tmp' in a page variable assignment."))
         end
-        if haskey(vars, key)
+        exists = haskey(vars, key)
+        # aliases are allowed for some global variables
+        if !exists && isglobal && haskey(GLOBAL_VARS_ALIASES, key)
+            exists = true
+            key = GLOBAL_VARS_ALIASES[key]
+        end
+        if exists
             # if the retrieved value has the right type, assign it to the corresponding key
             type_tmp  = typeof(tmp)
             acc_types = vars[key].second

--- a/test/global/rss_sitemap.jl
+++ b/test/global/rss_sitemap.jl
@@ -12,3 +12,19 @@
     @test occursin(raw"""<link>https://tlienart.github.io/FranklinTemplates.jl/menu1/index.html</link>""", fc)
     @test occursin(raw"""<description><![CDATA[A short description of the page which would serve as <strong>blurb</strong> in a <code>RSS</code> feed;""", fc)
 end
+
+@testset "Sitemap gen" begin
+    f = joinpath(p, "basic", "__site", "sitemap.xml")
+    @test isfile(f)
+    fc = prod(readlines(f, keep=true))
+
+    @test occursin(raw"""
+        <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">""", fc)
+    # check pages
+    for pg in ("", "menu1", "menu2", "menu3")
+        pgg = joinpath(pg, "index.html")
+        @test occursin("""
+            <loc>https://tlienart.github.io/FranklinTemplates.jl/$pgg</loc>""", fc)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,7 +94,7 @@ begin
     # windows can't delete the folder)
     mkdir(p); cd(p);
     include("global/postprocess.jl");
-    include("global/rss.jl")
+    include("global/rss_sitemap.jl")
     cd(p)
     include("global/eval.jl")
     cd(joinpath(D, ".."))


### PR DESCRIPTION
* #621 skip code eval for delayed pages
* #599 remove quotes for anchor generation
* #491 add sitemap generation
* introduce aliases for common global variables
  * `prefix` => `prepath`
  * `base_path` => `prepath`
  * `base_url` => `website_url`

### Sitemap generation

**global vars**

* `website_url` (also used for RSS)
* `generate_sitemap` `true|false`

**local vars**

* `sitemap_exclude` `false|true`
* `sitemap_changefreq` `"monthly" | "always", "hourly", "daily", "weekly", "yearly", "never"`
* `sitemap_lastmod` (extracted from file last modification)
* `sitemap_priority` `0.5 | [0, 1]`

**hfun**

For a HTML page (e.g. landing page or other custom html page)

```
{{sitemap_opts exclude}} 
```

or

```
{{sitemap_opts yearly 0.7}}
```