### PR TITLE
Adding a section of the documentation about (custom) tag pages

### DIFF
--- a/docs/workflow/index.md
+++ b/docs/workflow/index.md
@@ -123,6 +123,10 @@ To avoid name clashes, refrain from using the following paths where `/` indicate
 
 Also bear in mind that Franklin will ignore `README.md`, `LICENSE.md`, `Manifest.toml` and `Project.toml`.
 
+### Tag pages
+
+All pages with a given tag can be found (by default) at `[website]/tag/<tag_name>`. The tag page location can be changed by setting the `tag_page_path` variable in `config.md`. For example, setting `@def tag_page_path = "my_tags"` would cause tag pages to appear at `[website]/my_tags/<tag_name>`.
+
 ### Editing and testing your website
 
 The `serve` function can be used to launch a server which will track and render modifications.


### PR DESCRIPTION
The location and function of tag pages was not covered in the documentation. This adds a section to the site layout sections of the docs that covers the location of tag pages and how to set custom tag page locations (as discussed in #604 and #608).