### PR TITLE
Remove ref to franklindocs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Go to [Franklin's main website](https://franklinjl.org).
 
 Some examples of websites using Franklin (_if you're using Franklin with a public repo, consider adding the "franklin" tag to the repo to help others find examples, thanks!_)
 
-* Franklin's own website is written in Franklin, [source](https://github.com/tlienart/franklindocs)
+* Franklin's own website is written in Franklin, [see docs/](docs/)
 * The [Julia website](https://julialang.org), including the blog, are deployed in Franklin.
 * [@cormullion's website](https://cormullion.github.io), the author of [Luxor.jl](https://github.com/JuliaGraphics/Luxor.jl),
 * MLJ's [tutorial website](https://alan-turing-institute.github.io/DataScienceTutorials.jl/) which shows how Franklin can interact nicely with [Literate.jl](https://github.com/fredrikekre/Literate.jl)

--- a/docs/_layout/head.html
+++ b/docs/_layout/head.html
@@ -104,7 +104,7 @@
         <div class="main-header">
           <a name="pagetop"></a>
 
-          <a id="github" href="https://github.com/tlienart/franklindocs/blob/master/{{fd_rpath}}">Page source</a>
+          <a id="github" href="https://github.com/tlienart/Franklin.jl/blob/master/docs/{{fd_rpath}}">Page source</a>
 		  <span style="width:30px; text-align: center;color:lightgray;">|</span>
 		  <a id="github" href="https://github.com/tlienart/Franklin.jl">GitHub Repository</a>
         </div>

--- a/docs/extras/lunr.md
+++ b/docs/extras/lunr.md
@@ -24,7 +24,7 @@ $> npm install cheerio
 
 ### Files
 
-Copy [this folder](https://github.com/tlienart/franklindocs/tree/master/_libs/lunr) to a `/_libs/lunr/` directory.
+Copy [this folder](https://github.com/tlienart/Franklin.jl/tree/master/docs/_libs/lunr) to a `/_libs/lunr/` directory.
 Discard the `lunr_index.js` which is the index of this website, you will rebuild your own of course!
 
 The important files are `build_index.js` and `lunrclient.js` (of  which a minified version is provided which you will want to re-generate if you modify the base file).


### PR DESCRIPTION
I found three links to an archived repo.

I am not sure about the change in the README.md (source -> see docs/). What do you think?