### PR TITLE
Add robots.txt

### DIFF
--- a/docs/workflow/sitemap-rss.md
+++ b/docs/workflow/sitemap-rss.md
@@ -63,11 +63,9 @@ By default, the file will contain a link to your sitemap, if one is generated, a
 For a given _markdown_ page (extension `.md`) you can disallow it by setting the [page variable](/syntax/page-variables/) `robots_disallow_this_page` to `true`, you could have in your markdown:
 
 ```plaintext
-+++
 @def robots_disallow_this_page = true
-+++
 ```
 
-You can also disallow folders by setting the global variable `robots_disallow` to a vector of folders like `[/folder1/, /folder2/]` in your `config.md`. To disallow the whole website, you can set `robots_disallow = [/]`.
+You can also disallow folders by setting the global variable `robots_disallow` to a vector of folders like `["folder1/", "folder2/"]` in your `config.md`. To disallow the whole website, you can set `robots_disallow = ["/"]`.
 
 Note that you can disable the generation of the `robots.txt` file by setting the global variable `generate_robots` to `false` in your `config.md`.

--- a/docs/workflow/sitemap-rss.md
+++ b/docs/workflow/sitemap-rss.md
@@ -2,7 +2,7 @@
 reviewed: 18/10/20
 -->
 
-# RSS and Sitemap
+# RSS, Sitemap and Robots
 
 \toc
 
@@ -54,3 +54,20 @@ This is only supported for pages with a _markdown_ source for now and you must d
 Click [here](/syntax/page-variables/#rss) for more details on the page variables related to the RSS feed.
 
 Note that you can also disable the rss generation completely by setting the global page variable `generate_rss` to `false` in your `config.md`.
+
+## Robots
+
+Franklin automatically generates a [robots.txt](https://www.robotstxt.org/) file for your website which you can adjust as required.
+By default, the file will contain a link to your sitemap, if one is generated, and no page will be disallowed to robots.
+
+For a given _markdown_ page (extension `.md`) you can disallow it by setting the [page variable](/syntax/page-variables/) `robots_disallow_this_page` to `true`, you could have in your markdown:
+
+```plaintext
++++
+@def robots_disallow_this_page = true
++++
+```
+
+You can also disallow folders by setting the global variable `robots_disallow` to a vector of folders like `[/folder1/, /folder2/]` in your `config.md`. To disallow the whole website, you can set `robots_disallow = [/]`.
+
+Note that you can disable the generation of the `robots.txt` file by setting the global variable `generate_robots` to `false` in your `config.md`.

--- a/src/Franklin.jl
+++ b/src/Franklin.jl
@@ -205,6 +205,7 @@ include("converter/html/prerender.jl")
 # FILE AND DIR MANAGEMENT
 include("manager/rss_generator.jl")
 include("manager/sitemap_generator.jl")
+include("manager/robots_generator.jl")
 include("manager/write_page.jl")
 include("manager/dir_utils.jl")
 include("manager/file_utils.jl")

--- a/src/manager/franklin.jl
+++ b/src/manager/franklin.jl
@@ -270,6 +270,8 @@ function fd_fullpass(watched_files::NamedTuple)::Int
     generate_tag_pages()
     # generate sitemap if appropriate
     globvar("generate_sitemap") && sitemap_generator()
+    # generate robots if appropriate
+    globvar("generate_robots") && robots_generator()
     # done
     FD_ENV[:FULL_PASS] = false
     # return -1 if any page failed to build, 0 otherwise

--- a/src/manager/robots_generator.jl
+++ b/src/manager/robots_generator.jl
@@ -33,7 +33,7 @@ function robots_generator()
     print(io, """
         User-agent: *
         """)
-    if !(all(isempty, (DISALLOW, globvar(:robots_disallow)))
+    if !(all(isempty, (DISALLOW, globvar(:robots_disallow))))
         for page in DISALLOW
             print(io, """
                 Disallow: $page

--- a/src/manager/robots_generator.jl
+++ b/src/manager/robots_generator.jl
@@ -15,7 +15,7 @@ function add_disallow_item()
     loc = url_curpage()
     loc in DISALLOW && return nothing
     push!(DISALLOW, loc)
-    return loc
+    return nothing
 end
 
 """
@@ -33,15 +33,18 @@ function robots_generator()
     print(io, """
         User-agent: *
         """)
-    if length(DISALLOW) != 0 || length(globvar(:robots_disallow)) != 0
+    if !(all(isempty, (DISALLOW, globvar(:robots_disallow)))
         for page in DISALLOW
             print(io, """
                 Disallow: $page
                 """)
         end
         for dir in globvar(:robots_disallow)
+            if dir == "/"
+                dir = ""
+            end
             print(io, """
-                Disallow: $dir
+                Disallow: /$dir
                 """)
         end
     else

--- a/src/manager/robots_generator.jl
+++ b/src/manager/robots_generator.jl
@@ -1,0 +1,54 @@
+# Sitemap: $(joinpath(path(:site), "sitemap.xml"))
+#
+# User-agent: *
+# Disallow:
+#
+
+const DISALLOW = Vector{String}()
+
+"""
+$SIGNATURES
+
+Add an entry to `DISALLOW`.
+"""
+function add_disallow_item()
+    loc = url_curpage()
+    loc in DISALLOW && return nothing
+    push!(DISALLOW, loc)
+    return loc
+end
+
+"""
+$SIGNATURES
+
+Generate a `robots.txt`, if one already exists, it will be replaced.
+"""
+function robots_generator()
+    dst = joinpath(path(:site), "robots.txt")
+    isfile(dst) && rm(dst)
+    io = IOBuffer()
+    globvar(:generate_sitemap) && println(io, """
+        Sitemap: $(joinpath(globvar(:website_url), "sitemap.xml"))
+        """)
+    print(io, """
+        User-agent: *
+        """)
+    if length(DISALLOW) != 0 || length(globvar(:robots_disallow)) != 0
+        for page in DISALLOW
+            print(io, """
+                Disallow: $page
+                """)
+        end
+        for dir in globvar(:robots_disallow)
+            print(io, """
+                Disallow: $dir
+                """)
+        end
+    else
+        print(io, """
+            Disallow:
+            """)
+    end
+    write(dst, take!(io))
+    return nothing
+end

--- a/src/manager/write_page.jl
+++ b/src/manager/write_page.jl
@@ -183,6 +183,10 @@ function convert_and_write(root::String, file::String, head::String,
     cond_add = globvar(:generate_sitemap) && FD_ENV[:FULL_PASS]
     cond_add && add_sitemap_item()
 
+    # Same for disallow robots locally
+    cond_add = locvar(:robots_disallow_this_page)
+    cond_add && add_disallow_item()
+
     pg = write_page(output_path, content; head=head, pgfoot=pgfoot, foot=foot)
 
     # 6. possible post-processing via the "on-write" function.

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -33,7 +33,7 @@ const GLOBAL_VARS_DEFAULT = [
     # will be added to IGNORE_FILES
     "ignore"           => Pair(String[], (Vector{Any},)),
     # for robots.txt
-    "robots_disallow"  => Pair(String[], (Vector{Any},)),
+    "robots_disallow"  => Pair(String[], (Vector{String},)),
     "generate_robots"  => dpair(true),
     # RSS + sitemap
     "website_title"    => dpair(""),

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -32,6 +32,9 @@ const GLOBAL_VARS_DEFAULT = [
     "tag_page_path"    => dpair("tag"),
     # will be added to IGNORE_FILES
     "ignore"           => Pair(String[], (Vector{Any},)),
+    # for robots.txt
+    "robots_disallow"  => Pair(String[], (Vector{Any},)),
+    "generate_robots"  => dpair(true),
     # RSS + sitemap
     "website_title"    => dpair(""),
     "website_descr"    => dpair(""),
@@ -111,6 +114,9 @@ const LOCAL_VARS_DEFAULT = [
     "sitemap_changefreq" => dpair("monthly"),
     "sitemap_priority"   => dpair(0.5),
     "sitemap_exclude"    => dpair(false),
+    # -------------
+    # ROBOTS.TXT
+    "robots_disallow_this_page" => dpair(false),
     # -------------
     # MISCELLANEOUS (should not be modified)
     "fd_mtime_raw" => dpair(Date(1)),

--- a/test/global/rss_sitemap.jl
+++ b/test/global/rss_sitemap.jl
@@ -28,3 +28,12 @@ end
             <loc>https://tlienart.github.io/FranklinTemplates.jl/$pgg</loc>""", fc)
     end
 end
+
+@testset "Robots.txt gen" begin
+    f = joinpath(p, "basic", "__site", "robots.txt")
+    @test isfile(f)
+    fc = prod(readlines(f, keep=true))
+
+    @test occursin(raw"""
+        Sitemap: https://tlienart.github.io/FranklinTemplates.jl/sitemap.xml""", fc)
+end


### PR DESCRIPTION
As I totally messed up #653 I reopen a cleaner PR. Sorry for that.

This is the first step to resolve #651

How it is done elsewhere:
- Jekyll generates its `robots.txt` with the `sitemap` generation: see [https://github.com/jekyll/jekyll-sitemap](https://github.com/jekyll/jekyll-sitemap)
- Hugo generates `robots.txt` has a template(?). I am not sure I understood the way it works. However I am not familiar with any of the involved technologies and it might be straightforward for others. See [https://github.com/gohugoio/hugo/blob/master/docs/content/en/templates/robots.md](https://github.com/gohugoio/hugo/blob/master/docs/content/en/templates/robots.md)

As a `sitemap_generator` is present in Franklin, I went for a `robots_generator` that include a line that links to sitemap.xml.
See [here](https://en.wikipedia.org/wiki/Robots_exclusion_standard#Sitemap) or [here](https://www.sitemaps.org/protocol.html#submit_robots) for more information on `Sitemap:` keyword.


State of the discussion:
> it makes more sense to make this a global parameter where you specify paths to directories to exclude

> for individual files a `@def disallow_robots = true` or similar seems simpler to use

> there's a choice as to how many such "disallow" a user would want

> I think a simple test could be added where you pre-specify the base url by doing
> ```Franklin.set_var!(Franklin.GLOBAL_VARS, "website_url", "https://www.example.com")```
> and then call your function and check that it produces the right file in a temp folder

I'm not sure I did exactly what you suggested here. Is the test I added ok?


TODO
- [ ] Add info about robots in [FranklinTemplate.jl](https://github.com/tlienart/FranklinTemplates.jl) so `newsite()` prepare `@def nicenamefordisallowingrobots = []`