### PR TITLE
closes #678 and minor small fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.10.8"
+version = "0.10.9"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/converter/markdown/mddefs.jl
+++ b/src/converter/markdown/mddefs.jl
@@ -100,7 +100,7 @@ function process_mddefs(blocks::Vector{OCBlock}, isconfig::Bool,
     (:process_mddefs, "assignments done & copy to ALL_PAGE_VARS") |> logger
 
     # TAGS
-    tags = Set(locvar(:tags))
+    tags = Set(refstring.(locvar(:tags)))
     # Cases:
     # 0. there was no page tags before
     #   a. tags is empty --> do nothing

--- a/src/scripts/minify.py
+++ b/src/scripts/minify.py
@@ -5,12 +5,10 @@
 import os
 from css_html_js_minify import process_single_html_file as min_html
 from css_html_js_minify import process_single_css_file as min_css
-from multiprocessing import Pool, cpu_count
-from functools import partial
 
 # modify those if you're not using the standard output paths.
 html_files = []
-css_files  = []
+css_files = []
 for root, dirs, files in os.walk("__site"):
     for fname in files:
         path = os.path.join(root, fname)
@@ -25,18 +23,7 @@ for root, dirs, files in os.walk("__site"):
 
 css_files = [cf for cf in css_files if not cf.endswith(".min.css")]
 
-
-if os.name == 'nt':
-    # multiprocessing doesn't seem to go well with windows...
-    for file in html_files:
-        min_html(file, overwrite=True)
-    for file in css_files:
-        min_css(file, overwrite=True)
-else:
-    pool = Pool(cpu_count())
-
-    pool.map_async(partial(min_html, overwrite=True), html_files)
-    pool.map_async(partial(min_css, overwrite=True), css_files)
-
-    pool.close()
-    pool.join()
+for file in html_files:
+    min_html(file, overwrite=True)
+for file in css_files:
+    min_css(file, overwrite=True)

--- a/test/converter/md/tags.jl
+++ b/test/converter/md/tags.jl
@@ -68,13 +68,13 @@ end
         @def title = "Page 3"
         """)
     write(joinpath("blog", "pg4.md"), """
-        @def tags = ["aa", "dd", "ee"]
+        @def tags = ["aa", "dd", "ee", "ee 00"]
         @def date = Date(2003, 01, 01)
         @def title = "Page 4"
         """)
     serve(clear=true, single=true, cleanup=false, nomess=true)
     @test isdir(joinpath("__site", "tag"))
-    for tag in ("aa", "bb", "cc", "dd", "ee")
+    for tag in ("aa", "bb", "cc", "dd", "ee", "ee_00")
         local p
         p = joinpath("__site", "tag", tag, "index.html")
         @test isfile(p)

--- a/test/global/postprocess.jl
+++ b/test/global/postprocess.jl
@@ -91,6 +91,6 @@ if F.FD_CAN_PRERENDER; @testset "prerender" begin
         jshl = F.js_prerender_highlight(hs)
         # conversion of the code
         @test occursin("""<pre><code class="julia hljs"><span class="hljs-keyword">using</span>""", jshl)
-        @test occursin(raw"""<span class="hljs-string">"hello <span class="hljs-variable">$b</span>"</span>""", jshl)
+        @test occursin(raw"""<span class=\"hljs-comment\"># Woodbury formula</span>""", jshl)
     end; end # if can highlight
 end; end # if can prerender


### PR DESCRIPTION
Tags with spaces now go through the `refstring` function (like headers) so that something like `tag 01` becomes `tag_01`