### PR TITLE
Generate tag-filtered RSS feeds, fixes #463.

### DIFF
--- a/test/coverage/extras1.jl
+++ b/test/coverage/extras1.jl
@@ -47,7 +47,7 @@ end
 
 @testset "RSS" begin
     F.set_var!(F.GLOBAL_VARS, "website_descr", "")
-    F.RSS_DICT["hello"] = F.RSSItem("","","","","","","",Date(1))
+    F.RSS_DICT["hello"] = (F.RSSItem("","","","","","","",Date(1)), String[])
     global r = ""; s = @capture_out begin
         global r
         r = F.rss_generator()

--- a/test/manager/rss.jl
+++ b/test/manager/rss.jl
@@ -19,28 +19,71 @@ end
     F.set_var!(F.GLOBAL_VARS, "website_title", "Website title")
     F.set_var!(F.GLOBAL_VARS, "website_descr", "Website descr")
     F.set_var!(F.GLOBAL_VARS, "website_url", "https://github.com/tlienart/Franklin.jl/")
+
+    # Page 1 with tags = ["foo"]
+    F.def_LOCAL_VARS!()
+    set_curpath("hey/hello.md")
+    F.set_var!(F.LOCAL_VARS, "rss_title", "title 1")
+    F.set_var!(F.LOCAL_VARS, "rss", "Page with tag foo.")
+    F.set_var!(F.LOCAL_VARS, "rss_pubdate", Date(2020, 10, 27))
+    F.set_var!(F.LOCAL_VARS, "tags", ["foo"])
+
+    item, tags = F.add_rss_item()
+    @test item.title == "title 1"
+    @test item.description == "Page with tag foo.\n"
+    @test item.author == ""
+    @test item.pubDate == Date(2020, 10, 27)
+    @test tags == ["foo"]
+    @test F.RSS_DICT["/hey/hello/index.html"][1].description == item.description
+    @test F.RSS_DICT["/hey/hello/index.html"][2] == ["foo"]
+
+    # Page 2 with tags = ["foo", "bar"]
     F.def_LOCAL_VARS!()
     set_curpath("hey/ho.md")
-    F.set_var!(F.LOCAL_VARS, "rss_title", "title")
-    F.set_var!(F.LOCAL_VARS, "rss", "A **description** done.")
+    F.set_var!(F.LOCAL_VARS, "rss_title", "title 2")
+    F.set_var!(F.LOCAL_VARS, "rss", "A **description** done. Page with tags foo and bar.")
+    F.set_var!(F.LOCAL_VARS, "rss_pubdate", Date(2020, 10, 30))
     F.set_var!(F.LOCAL_VARS, "rss_author", "chuck@norris.com")
+    F.set_var!(F.LOCAL_VARS, "tags", ["foo", "bar"])
 
-    item = F.add_rss_item()
-    @test item.title == "title"
-    @test item.description == "A <strong>description</strong> done.\n"
+    item, tags = F.add_rss_item()
+    @test item.title == "title 2"
+    @test item.description == "A <strong>description</strong> done. Page with tags foo and bar.\n"
     @test item.author == "chuck@norris.com"
-    # unchanged bc all three fallbacks lead to Data(1)
-    @test item.pubDate == Date(1)
-
-    F.set_var!(F.LOCAL_VARS, "rss_title", "")
-
-    @test F.RSS_DICT["/hey/ho/index.html"].description == item.description
+    @test item.pubDate == Date(2020, 10, 30)
+    @test tags == ["foo", "bar"]
+    @test F.RSS_DICT["/hey/ho/index.html"][1].description == item.description
+    @test F.RSS_DICT["/hey/ho/index.html"][2] == ["foo", "bar"]
 
     # Generation
     F.PATHS[:folder] = td
     F.rss_generator()
+    ## Global feed
     feed = joinpath(F.PATHS[:site], "feed.xml")
     @test isfile(feed)
-    fc = prod(readlines(feed, keep=true))
-    @test occursin("<description><![CDATA[A <strong>description</strong> done.", fc)
+    fc = read(feed, String)
+    @test occursin("<description><![CDATA[A <strong>description</strong> done. Page with tags foo and bar.", fc)
+    @test occursin("<description><![CDATA[Page with tag foo.", fc)
+    @test occursin("<pubDate>Fri, 30 Oct 2020 00:00:00 UT</pubDate>", fc)
+    @test occursin("<pubDate>Tue, 27 Oct 2020 00:00:00 UT</pubDate>", fc)
+    @test findfirst("Fri, 30 Oct 2020", fc) < findfirst("27 Oct 2020", fc) # ordered by pubDate
+
+    ## Tag filtered feeds
+    ### foo tag
+    feed = joinpath(F.PATHS[:tag], "foo", "feed.xml")
+    @test isfile(feed)
+    foo_feed = read(feed, String)
+    @test occursin("<description><![CDATA[A <strong>description</strong> done. Page with tags foo and bar.", foo_feed)
+    @test occursin("<description><![CDATA[Page with tag foo.", foo_feed)
+    @test occursin("<pubDate>Fri, 30 Oct 2020 00:00:00 UT</pubDate>", foo_feed)
+    @test occursin("<pubDate>Tue, 27 Oct 2020 00:00:00 UT</pubDate>", foo_feed)
+    @test findfirst("Fri, 30 Oct 2020", foo_feed) < findfirst("27 Oct 2020", foo_feed) # ordered by pubDate
+    ### bar tag
+    feed = joinpath(F.PATHS[:tag], "bar", "feed.xml")
+    @test isfile(feed)
+    bar_feed = read(feed, String)
+    @test occursin("<description><![CDATA[A <strong>description</strong> done. Page with tags foo and bar.", bar_feed)
+    @test !occursin("<description><![CDATA[Page with tag foo.", bar_feed)
+    @test occursin("<pubDate>Fri, 30 Oct 2020 00:00:00 UT</pubDate>", bar_feed)
+    @test !occursin("<pubDate>Tue, 27 Oct 2020 00:00:00 UT</pubDate>", bar_feed)
 end


### PR DESCRIPTION
This implements tag-specific feeds located at `/tag/XXX/feed.xml`. They are equivalent to the global feed (e.g. same `<title>`/`<description>`/`<link>` as the global one), it is just the `<items>` that are filtered.