### PR TITLE
Remove sandbox module information in \show

### DIFF
--- a/demos/index.md
+++ b/demos/index.md
@@ -17,6 +17,37 @@ The ordering is reverse chronological but just use the table of contents to guid
 
 \toc
 
+## (011) showing type information
+
+This is a short demo following a discussion on Slack:
+
+```julia:extype
+struct T; v::Int; end
+[
+    Dict(:a => T(1)),
+    Dict(:b => T(2)),
+]
+```
+\show{extype}
+
+## (010) clipboard button for code blocks
+
+It's fairly easy to add a "copy" button to your code blocks using  a tool like [`clipboard.js`](https://clipboardjs.com).
+In fact on this demo page, as you can see, there is a copy button on all code blocks.
+The steps to  reproduce  this are:
+
+* copy the [`clipboard.min.js`](https://github.com/tlienart/Franklin.jl/blob/master/demos/_libs/clipboard.min.js) to `/libs/clipboard.min.js` (_note that this is an old version of the library, `1.4` or something, if you take  the most recent version, you will have to adapt the script_)
+* load that in `_layout/head.html` adding something like
+
+```html
+<script src="/libs/clipboard.min.js"></script>
+```
+
+* add Javascript in the `_layout/foot.html`,  something [like this](https://github.com/tlienart/Franklin.jl/blob/master/demos/_layout/foot_clipboard.html)
+* adjust the CSS, for instance [something like this](https://github.com/tlienart/Franklin.jl/blob/0276b1afb054017ff7e81bc7d083021a867a4b92/demos/_css/extras.css#L37-L61)
+
+and that's it 🏁.
+
 ## (009) custom environment for TikzCD
 
 Following up on [#008](#008_custom_environments_and_commands), here's a custom environment for Tikz diagrams using the [TikzCDs.jl](https://github.com/JuliaTeX/TikzCDs.jl) package.

--- a/src/converter/latex/io.jl
+++ b/src/converter/latex/io.jl
@@ -1,4 +1,6 @@
 """
+    \\input{qualifier}{rpath}
+
 Resolve a command of the form `\\input{qualifier}{rpath}` where
 
 * `qualifier` indicates what should be inserted (either a code block or a
@@ -72,6 +74,8 @@ end
 
 
 """
+    \\output{...}
+
 Return the output of a code. Possibly including the result of the code
 (`res=true`) and possibly reprocessing the whole (`reproc=true`).
 At most one will be true. See [`lx_show`](@ref).
@@ -95,7 +99,7 @@ function lx_output(lxc::LxCom, lxd::Vector{LxDef};
             if !isempty(output) && !endswith(output, "\n")
                 output *= "\n"
             end
-            output *= result
+            output *= replace(result, r"Main\.FD_SANDBOX_[0-9]+\." => "")
         end
     end
     # should it be reprocessed ?
@@ -104,16 +108,22 @@ function lx_output(lxc::LxCom, lxd::Vector{LxDef};
 end
 
 """
+    \\textoutput{...}
+
 Same as [`output`](@ref) but with re-processing.
 """
 lx_textoutput(lxc::LxCom, lxd) = lx_output(lxc, lxd; reproc=true)
 
 """
+    \\show{...}
+
 Same as [`output`](@ref) but adding the result.
 """
 lx_show(lxc::LxCom, lxd) = lx_output(lxc, lxd; res=true)
 
 """
+    \\textinput{...}
+
 Resolve a `\\textinput{rpath}` command: insert **and reprocess** some text.
 If you just want to include text as a plaintext block use
 `\\input{plaintext}{rpath}` instead.
@@ -131,6 +141,8 @@ function lx_textinput(lxc::LxCom, lxd::Vector{LxDef})
 end
 
 """
+    \\figalt{...}{...}
+
 Resolve a `\\figalt{alt}{rpath}` (find a fig and include it with alt).
 """
 function lx_figalt(lxc::LxCom, _)
@@ -166,6 +178,8 @@ function lx_figalt(lxc::LxCom, _)
 end
 
 """
+    \\tableinput{...}{...}
+
 Resolve a `\\tableinput{header}{rpath}` (find a table+header and include it).
 """
 function lx_tableinput(lxc::LxCom, _)
@@ -192,6 +206,8 @@ function lx_tableinput(lxc::LxCom, _)
 end
 
 """
+    \\liteate{...}
+
 Resolve a `\\literate{rpath}` (find a literate script and insert it).
 """
 function lx_literate(lxc::LxCom, lxd::Vector{LxDef})


### PR DESCRIPTION
Removes `Main.FD_SANDBOX_....` when using `\show` of a code output, this leads to shown output as if they were evaluated in the REPL:

<img width="435" alt="Screenshot 2020-11-03 at 11 11 48" src="https://user-images.githubusercontent.com/10897531/97972954-9d509980-1dc5-11eb-9ec4-191c6105788e.png">

What this PR does is simply to replace `Main.FD_SANDBOX_...` in output, this, I think, should generally be satisfactory (even if a user defines a module within a code block).

cc: @aviatesk who kindly reported this.

closes #690, also closes #688 