### PR TITLE
Add 'notebook-style' eval blocks

### DIFF
--- a/demos/index.md
+++ b/demos/index.md
@@ -19,16 +19,28 @@ The ordering is reverse chronological but just use the table of contents to guid
 
 ## (011) showing type information
 
-This is a short demo following a discussion on Slack:
+This is a short demo following a discussion on Slack, it shows three things:
 
-```julia:extype
+* how to mark a block as "_run here directly and show the output_" without having to explicitly add a path and use a `\show`
+* that types are now shown properly as they would be in the REPL.
+* that continuation works from cell to cell (i.e. you can assume that a cell further below another cell has access to what was defined in the first)
+
+```!
+s = "hello"
 struct T; v::Int; end
 [
     Dict(:a => T(1)),
     Dict(:b => T(2)),
 ]
 ```
-\show{extype}
+
+Here's another cell
+
+```!
+T(1)
+print(s)
+```
+
 
 ## (010) clipboard button for code blocks
 

--- a/src/converter/markdown/blocks.jl
+++ b/src/converter/markdown/blocks.jl
@@ -14,8 +14,9 @@ function convert_block(β::AbstractBlock, lxdefs::Vector{LxDef})::AS
 
     βn == :CODE_INLINE     && return html_code_inline(stent(β) |> htmlesc)
     βn == :CODE_BLOCK_LANG && return resolve_code_block(β.ss)
-    βn == :CODE_BLOCK_IND  && return convert_indented_code_block(β.ss)
+    βn == :CODE_BLOCK!     && return resolve_code_block(β.ss, shortcut=true)
     βn == :CODE_BLOCK      && return html_code(stent(β), "{{fill lang}}")
+    βn == :CODE_BLOCK_IND  && return convert_indented_code_block(β.ss)
 
     βn == :ESCAPE          && return chop(β.ss, head=3, tail=3)
     βn == :FOOTNOTE_REF    && return convert_footnote_ref(β)

--- a/src/parser/markdown/tokens.jl
+++ b/src/parser/markdown/tokens.jl
@@ -89,6 +89,7 @@ const MD_TOKENS = LittleDict{Char, Vector{TokenFinder}}(
               isexactly("``", ('`',), false)  => :CODE_DOUBLE, # ``⎵*
               # 3+ can be named
               isexactly("```",   SPACE_CHAR) => :CODE_TRIPLE, # ```⎵*
+              isexactly("```!",  SPACE_CHAR) => :CODE_TRIPLE!,# ```!⎵*
               is_language(3)                 => :CODE_LANG3,  # ```lang*
               isexactly("````",  SPACE_CHAR) => :CODE_QUAD,   # ````⎵*
               is_language(4)                 => :CODE_LANG4,  # ````lang*
@@ -146,6 +147,7 @@ const MD_OCB = [
     OCProto(:CODE_BLOCK_LANG, :CODE_LANG3,   (:CODE_TRIPLE,)  ),
     OCProto(:CODE_BLOCK_LANG, :CODE_LANG4,   (:CODE_QUAD,)    ),
     OCProto(:CODE_BLOCK_LANG, :CODE_LANG5,   (:CODE_PENTA,)   ),
+    OCProto(:CODE_BLOCK!,     :CODE_TRIPLE!, (:CODE_TRIPLE,)  ),
     OCProto(:CODE_BLOCK,      :CODE_TRIPLE,  (:CODE_TRIPLE,)  ),
     OCProto(:CODE_BLOCK,      :CODE_QUAD,    (:CODE_QUAD,)    ),
     OCProto(:CODE_BLOCK,      :CODE_PENTA,   (:CODE_PENTA,)   ),
@@ -253,7 +255,7 @@ CODE_BLOCKS_NAMES
 
 List of names of code blocks environments.
 """
-const CODE_BLOCKS_NAMES = (:CODE_BLOCK_LANG, :CODE_BLOCK, :CODE_BLOCK_IND)
+const CODE_BLOCKS_NAMES = (:CODE_BLOCK_LANG, :CODE_BLOCK, :CODE_BLOCK!, :CODE_BLOCK_IND)
 
 """
     MD_CLOSEP

--- a/src/regexes.jl
+++ b/src/regexes.jl
@@ -62,12 +62,14 @@ const FN_DEF_PAT = r"^\[\^[\p{L}0-9_]+\](:)?$"
 CODE blocks
 ===================================================== =#
 
+const CODE_3!_PAT = r"```\!\s*\n?((?:.|\n)*)```"
+
 const CODE_3_PAT = Regex(
         "```([a-zA-Z][a-zA-Z-]*)" *    # language
         "(?:(" * # optional script name
             "\\:[\\p{L}\\\\\\/_\\.]" * # :(...) start of script name
-            "[\\p{L}_0-9-\\\\\\/]+" *  # script name
-            "(?:\\.[a-zA-Z0-9]+)?" *  # script extension
+            "[\\p{L}_0-9-\\\\\\/]+"  * # script name
+            "(?:\\.[a-zA-Z0-9]+)?"   * # script extension
         ")|(?:\\n|\\s))" *
         "\\s*\\n?((?:.|\\n)*)```") # rest of the code
 

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -118,13 +118,14 @@ const LOCAL_VARS_DEFAULT = [
     # ROBOTS.TXT
     "robots_disallow_this_page" => dpair(false),
     # -------------
-    # MISCELLANEOUS (should not be modified)
+    # MISCELLANEOUS (should not be modified by the user)
     "fd_mtime_raw" => dpair(Date(1)),
     "fd_ctime"     => dpair("0001-01-01"),  # time of creation
     "fd_mtime"     => dpair("0001-01-01"),  # time of last modification
-    "fd_rpath"     => dpair(""),       # rpath to current page [1]
-    "fd_url"       => dpair(""),       # url to current page [2]
-    "fd_tag"       => dpair(""),       # (generated) current tag
+    "fd_rpath"     => dpair(""),            # rpath to current page [1]
+    "fd_url"       => dpair(""),            # url to current page [2]
+    "fd_tag"       => dpair(""),            # (generated) current tag
+    "fd_evalc"     => dpair(1),             # counter for direct evaluation cells (3! blocks)
     ]
 #=
 NOTE:

--- a/test/eval/integration.jl
+++ b/test/eval/integration.jl
@@ -13,3 +13,30 @@
          <pre><code class="plaintext">12</code></pre>
         """)
 end
+
+
+@testset "shortcut" begin
+    a = """
+        A
+        ```!
+        x = 1
+        ```
+        B
+        ```!
+        print(x)
+        ```
+        """ |> fd2html
+    @test isapproxstr(a, """
+            <p>A</p>
+
+            <pre><code class="language-julia">
+            x &#61; 1
+            </code></pre>
+            <pre><code class="plaintext">1</code></pre>
+
+            <p>B</p>
+
+            <pre><code class="language-julia">print&#40;x&#41;</code></pre>
+            <pre><code class="plaintext">1</code></pre>
+            """)
+end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,4 +1,5 @@
 import DataStructures: OrderedDict
+import Base.//
 
 # This set of tests directly uses the high-level `convert` functions
 # And checks the behaviour is as expected.


### PR DESCRIPTION
Following a suggestion (see #683) users can now write

````
```!
x = 1
```
````

To mean the more verbose 

````
```julia:somename
x = 1
```
\show{somename}
````

So that's identical to what would happen in a default literate mode. 

**Notes**: 
* if you want to suppress output, just use a `;` at the end of your code block
* for now it only works with triple-backticks block; it wouldn't be hard to make it work for 4 and 5 backticks but right now I don't see the use case.

cc: @jkrumbiegel this will be on master only for now and I will release this in a few days but if you could test this and let me know if you encounter problems, that would be great

closes #683 