### PR TITLE
Suppress output if code ends with `;` irrelevant of whitespaces

### DIFF
--- a/demos/index.md
+++ b/demos/index.md
@@ -41,6 +41,12 @@ T(1)
 print(s)
 ```
 
+Suppressed output:
+
+```!
+X = randn(2, 3);
+```
+
 
 ## (010) clipboard button for code blocks
 

--- a/src/eval/run.jl
+++ b/src/eval/run.jl
@@ -88,7 +88,7 @@ function run_code(mod::Module, code::AS, out_path::AS;
         res = nothing
     end
     # if last bit ends with `;` return nothing (no display)
-    code[end] == ';' && return nothing
+    endswith(code, r";\s*") && return nothing
     # if last line is a Julia value return
     isa(exs[end], Expr) || return res
     # if last line of the code is a `show`


### PR DESCRIPTION
closes #695 