### PR TITLE
Show Symbol and Expr properly

### DIFF
--- a/demos/index.md
+++ b/demos/index.md
@@ -41,6 +41,12 @@ T(1)
 print(s)
 ```
 
+Suppressed output:
+
+```!
+X = randn(2, 3);
+```
+
 
 ## (010) clipboard button for code blocks
 

--- a/src/eval/codeblock.jl
+++ b/src/eval/codeblock.jl
@@ -127,7 +127,11 @@ function resolve_code_block(ss::SubString; shortcut=false)::String
         # >> this weird thing is to make sure that the proper "show"
         #    is called...
         io = IOBuffer()
-        Core.eval(mod, quote show($io, "text/plain", $res) end)
+        if typeof(res) in (Symbol, Expr)
+            show(io, res)
+        else
+            Core.eval(mod, quote show($io, "text/plain", $res) end)
+        end
         write(cp.res_path, take!(io))
         # >> since we've evaluated a code block, toggle scope as stale
         set_var!(LOCAL_VARS, "fd_eval", true)

--- a/src/eval/run.jl
+++ b/src/eval/run.jl
@@ -88,7 +88,7 @@ function run_code(mod::Module, code::AS, out_path::AS;
         res = nothing
     end
     # if last bit ends with `;` return nothing (no display)
-    code[end] == ';' && return nothing
+    endswith(code, r";\s*") && return nothing
     # if last line is a Julia value return
     isa(exs[end], Expr) || return res
     # if last line of the code is a `show`

--- a/test/eval/integration.jl
+++ b/test/eval/integration.jl
@@ -25,7 +25,7 @@ end
         ```!
         print(x)
         ```
-        """ |> fd2html
+        """ |> fd2html_td
     @test isapproxstr(a, """
             <p>A</p>
 
@@ -39,4 +39,28 @@ end
             <pre><code class="language-julia">print&#40;x&#41;</code></pre>
             <pre><code class="plaintext">1</code></pre>
             """)
+end
+
+
+@testset "#697" begin
+    a = """
+        A
+        ```!
+        x = :ab
+        ```
+        B
+        ```!
+        x = :(a+b)
+        ```
+        C
+        """ |> fd2html_td
+    @test isapproxstr(a, """
+        <p>A</p>
+        <pre><code class="language-julia">x &#61; :ab</code></pre>
+        <pre><code class="plaintext">:ab</code></pre>
+        <p>B</p>
+        <pre><code class="language-julia">x &#61; :&#40;a&#43;b&#41;</code></pre>
+        <pre><code class="plaintext">:(a + b)</code></pre>
+        <p>C</p>
+        """)
 end


### PR DESCRIPTION
Now

````
```!
x = :abc 
```
````

will show `:abc` instead of erroring saying that `abc` does not exist (#697) , same for expressions. 