### PR TITLE
Fix some links in FranklinDemo

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -2,6 +2,6 @@
 
 Trying to have demos for things people ask about.
 
-You can look at [the page](https://tlienart.github.io/FranklinFAQ/) with the questions and answers or at its source here (the page also makes reference to elements of the source).
+You can look at [the page](https://github.com/tlienart/Franklin.jl/tree/master/demos) with the questions and answers or at its source here (the page also makes reference to elements of the source).
 
 Please help by donating small demos of "how to do X" which we can point people to later. Thanks!

--- a/demos/README.md
+++ b/demos/README.md
@@ -2,6 +2,6 @@
 
 Trying to have demos for things people ask about.
 
-You can look at [the page](https://github.com/tlienart/Franklin.jl/tree/master/demos) with the questions and answers or at its source here (the page also makes reference to elements of the source).
+You can look at [the page](https://franklinjl.org/demos/) with the questions and answers or at its source here (the page also makes reference to elements of the source).
 
 Please help by donating small demos of "how to do X" which we can point people to later. Thanks!

--- a/demos/index.md
+++ b/demos/index.md
@@ -8,7 +8,7 @@
 This website is meant to be a quick way to show how to do stuff that people ask (or that I thought would be a nice demo), it will complement the [official documentation](https://franklinjl.org/).
 
 It's not meant to be beautiful, rather just show how to get specific stuff done.
-If one block answers one of your question, make sure to check [the source](https://github.com/tlienart/Franklin.jl/tree/master/demos) to see how it was done.
+If one block answers one of your question, make sure to check [the source](https://github.com/tlienart/Franklin.jl/tree/master/demos/index.md) to see how it was done.
 The ordering is reverse chronological but just use the table of contents to guide you to whatever you might want to explore.
 
 **Note**: an important philosophy here is that if you can write a Julia function that would produce the HTML you want, then write that function and let Franklin call it.

--- a/demos/index.md
+++ b/demos/index.md
@@ -8,7 +8,7 @@
 This website is meant to be a quick way to show how to do stuff that people ask (or that I thought would be a nice demo), it will complement the [official documentation](https://franklinjl.org/).
 
 It's not meant to be beautiful, rather just show how to get specific stuff done.
-If one block answers one of your question, make sure to check [the source](https://github.com/tlienart/FranklinFAQ/blob/master/index.md) to see how it was done.
+If one block answers one of your question, make sure to check [the source](https://github.com/tlienart/Franklin.jl/tree/master/demos) to see how it was done.
 The ordering is reverse chronological but just use the table of contents to guide you to whatever you might want to explore.
 
 **Note**: an important philosophy here is that if you can write a Julia function that would produce the HTML you want, then write that function and let Franklin call it.


### PR DESCRIPTION
Some links in FranklinDemo were pointing to the archived FranklinFAQ, so I fixed them to point to the correct destinations.