### PR TITLE
Shortcut for literate inclusion

### DIFF
--- a/src/eval/literate.jl
+++ b/src/eval/literate.jl
@@ -10,10 +10,11 @@ $SIGNATURES
 Take a Literate.jl script and transform it into a Franklin-Markdown file.
 """
 function literate_to_franklin(rpath::AS)::Tuple{String,Bool}
-    rpath *= ifelse(endwith(rpath, ".jl"), "", ".jl")
-    if !startswith(fpath, '/')
+    rpath *= ifelse(endswith(rpath, ".jl"), "", ".jl")
+    if !startswith(rpath, '/')
         # try looking into the `_literate` folder
         fpath = joinpath(path(:literate), rpath)
+        srpath = split(fpath)[1:end-1] # ignore the file name
     else
         # rpath is of the form "/scripts/[path/]tutorial[.jl]"
         # split it so that when recombining it will lead to valid path inc windows

--- a/src/eval/literate.jl
+++ b/src/eval/literate.jl
@@ -10,14 +10,16 @@ $SIGNATURES
 Take a Literate.jl script and transform it into a Franklin-Markdown file.
 """
 function literate_to_franklin(rpath::AS)::Tuple{String,Bool}
-    startswith(rpath, "/") || throw(
-        LiterateRelativePathError("Literate expects a path starting with '/'"))
-    # rpath is of the form "/scripts/[path/]tutorial[.jl]"
-    # split it so that when recombining it will lead to valid path inc windows
-    srpath = split(rpath, '/')[2:end] # discard empty [1] since starts with "/"
-    fpath  = joinpath(PATHS[:folder], srpath...)
-    # append `.jl` if required
-    endswith(fpath, ".jl") || (fpath *= ".jl")
+    rpath *= ifelse(endwith(rpath, ".jl"), "", ".jl")
+    if !startswith(fpath, '/')
+        # try looking into the `_literate` folder
+        fpath = joinpath(path(:literate), rpath)
+    else
+        # rpath is of the form "/scripts/[path/]tutorial[.jl]"
+        # split it so that when recombining it will lead to valid path inc windows
+        srpath = split(rpath, '/')[2:end] # discard empty [1] since starts with "/"
+        fpath  = joinpath(PATHS[:folder], srpath...)
+    end
     if !isfile(fpath)
         print_warning("""
             File not found when trying to  convert a literate file at '$fpath'.

--- a/test/integration/literate.jl
+++ b/test/integration/literate.jl
@@ -148,10 +148,10 @@ end
 end
 
 @testset "Literate-c" begin
-    s = raw"""
-        \literate{foo}
-        """
-    @test_throws F.LiterateRelativePathError (s |> fd2html_td)
+    # s = raw"""
+    #     \literate{/foo/bar/foo}
+    #     """
+    # @test_throws F.LiterateRelativePathError (s |> fd2html_td)
     s = raw"""
         \literate{/foo}
         """


### PR DESCRIPTION
allows

```
\literate{tutorial.jl}
```

with the assumption that the path, if it doesn't start with `/`, is probably in `_literate/` (if not, an error is thrown). 