### PR TITLE
Print stack trace

### DIFF
--- a/src/eval/run.jl
+++ b/src/eval/run.jl
@@ -23,9 +23,18 @@ function parse_code(code::AS)
     exs
 end
 
+"""
+$SIGNATURES
+
+Returns only the stack traces which are related to the user's code.
+This means removing stack traces pointing to Franklin's code.
+"""
 function trim_stacktrace(stacktrace::String)
+    # Franklin's stack traces always start with something like
+    # `(::Franklin.var"#96#98"{...})() at .../src/eval/run.jl:65`
     rx = r"\[\d+\]\s\(\:\:Franklin.var(?:.*?)src\/eval\/run.jl"
-    first_match_start = first(first(findall(rx, stacktrace)))
+    first_match_start = first(findfirst(rx, stacktrace))
+    # Keep only everything before the regex match.
     stacktrace[1:first_match_start-3]
 end
 

--- a/src/eval/run.jl
+++ b/src/eval/run.jl
@@ -67,6 +67,13 @@ function run_code(mod::Module, code::AS, out_path::AS;
                     showerror(io, e)
                     println(String(take!(io)))
                     err = typeof(e)
+
+                    # Print stacktrace.
+                    for (exc, bt) in Base.catch_stack()
+                        showerror(stderr, exc, bt)
+                        println(stderr, "")
+                    end
+
                     break
                 end
                 e += 1

--- a/src/eval/run.jl
+++ b/src/eval/run.jl
@@ -80,6 +80,11 @@ function run_code(mod::Module, code::AS, out_path::AS;
     end
     # if there was an error, return nothing and possibly show warning
     if !isnothing(err)
+        function strip_franklin(stacktrace::String)
+            rx = r"\[\d+\]\s\(\:\:Franklin.var(?:.*?)src\/eval\/run.jl"
+            first_match_start = first(first(findall(rx, stacktrace)))
+            stacktrace[1:first_match_start-3]
+        end
         FD_ENV[:SILENT_MODE] || print("\n")
         warn_err && print_warning("""
             There was an error of type '$err' when running a code block.
@@ -88,7 +93,7 @@ function run_code(mod::Module, code::AS, out_path::AS;
             \nRelevant pointers:
             $POINTER_EVAL
             \nStacktrace:
-            $stacktrace
+            $(strip_franklin(stacktrace))
             """)
         res = nothing
     end

--- a/src/eval/run.jl
+++ b/src/eval/run.jl
@@ -23,6 +23,12 @@ function parse_code(code::AS)
     exs
 end
 
+function trim_stacktrace(stacktrace::String)
+    rx = r"\[\d+\]\s\(\:\:Franklin.var(?:.*?)src\/eval\/run.jl"
+    first_match_start = first(first(findall(rx, stacktrace)))
+    stacktrace[1:first_match_start-3]
+end
+
 """
 $SIGNATURES
 
@@ -80,11 +86,6 @@ function run_code(mod::Module, code::AS, out_path::AS;
     end
     # if there was an error, return nothing and possibly show warning
     if !isnothing(err)
-        function strip_franklin(stacktrace::String)
-            rx = r"\[\d+\]\s\(\:\:Franklin.var(?:.*?)src\/eval\/run.jl"
-            first_match_start = first(first(findall(rx, stacktrace)))
-            stacktrace[1:first_match_start-3]
-        end
         FD_ENV[:SILENT_MODE] || print("\n")
         warn_err && print_warning("""
             There was an error of type '$err' when running a code block.
@@ -92,8 +93,8 @@ function run_code(mod::Module, code::AS, out_path::AS;
             might be helpful to understand and solve the issue.
             \nRelevant pointers:
             $POINTER_EVAL
-            \nStacktrace:
-            $(strip_franklin(stacktrace))
+            \nDetails:
+            $(trim_stacktrace(stacktrace))
             """)
         res = nothing
     end

--- a/test/eval/run.jl
+++ b/test/eval/run.jl
@@ -63,7 +63,23 @@ end
     @test isnothing(r)
     @test read(junk, String) == "x = 5\n"
 
-    # code with errorr
+    stacktrace = """
+        DomainError with -1.0:
+        sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
+        Stacktrace:
+         [1] throw_complex_domainerror(::Symbol, ::Float64) at ./math.jl:33
+         [2] sqrt at ./math.jl:573 [inlined]
+         [3] sqrt(::Int64) at ./math.jl:599
+         [4] top-level scope at none:1
+         [5] eval at ./boot.jl:331 [inlined]
+         [6] (::Franklin.var"#96#98"{Module,Array{Any,1},Int64})() at /home/rik/git/FR/src/eval/run.jl:71
+         [7] redirect_stdout(::Franklin.var"#96#98"{Module,Array{Any,1},Int64}, ::IOStream) at ./stream.jl:1150
+         [8] (::Franklin.var"#95#97"{Module,String,Array{Any,1},Int64})(::IOStream) at /home/rik/git/FR/src/eval/run.jl:67
+         [9] open(::Franklin.var"#95#97"{Module,String,Array{Any,1},Int64}, ::String, ::Vararg{String,N} where N; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at ./io.jl:325
+        """
+    @test !occursin("redirect_stdout", F.trim_stacktrace(stacktrace))
+
+    # code with error
     c = """
         e = 0
         a = sqrt(-1)

--- a/test/eval/run.jl
+++ b/test/eval/run.jl
@@ -74,6 +74,7 @@ end
     @test occursin("Warning: in <input string>", s)
     @test occursin("error of type 'DomainError'", s)
     @test occursin("Checking the output files", s)
+    @test occursin("throw_complex_domainerror(::Symbol, ::Float64) at", s)
 end
 
 @testset "i462" begin

--- a/test/eval/run.jl
+++ b/test/eval/run.jl
@@ -75,6 +75,7 @@ end
     @test occursin("error of type 'DomainError'", s)
     @test occursin("Checking the output files", s)
     @test occursin("throw_complex_domainerror(::Symbol, ::Float64) at", s)
+    @test !occursin("redirect_stdout", s)
 end
 
 @testset "i462" begin


### PR DESCRIPTION
When using Franklin, I usually know where the error is coming from, so then the current warning which only shows the error type is fine. However, at times I duly miss the stacktrace and am completely in the dark about the cause of an error.

Currently, this PR proposes to print the stacktrace to `stderr`. I think this is more convenient for the user than storing it in `outf`. (I also don't think the `outf` has ever been of much help for me. It typically contains the error I already had in the REPL in one file, and `nothing` in the other.)

The response is now something like 
```
DomainError with -1.0:
sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
Stacktrace:
 [1] throw_complex_domainerror(::Symbol, ::Float64) at ./math.jl:33
 [2] sqrt at ./math.jl:573 [inlined]
 [3] sqrt(::Int64) at ./math.jl:599
 [4] top-level scope at none:1
 [5] eval at ./boot.jl:331 [inlined]
 [6] (::Franklin.var"#96#98"{Module,Array{Any,1},Int64})() at /home/rik/FR/src/eval/run.jl:64
 [7] redirect_stdout(::Franklin.var"#96#98"{Module,Array{Any,1},Int64}, ::IOStream) at ./stream.jl:1150
 [8] (::Franklin.var"#95#97"{Module,String,Array{Any,1},Int64})(::IOStream) at /home/rik/FR/src/eval/run.jl:60
 [9] open(::Franklin.var"#95#97"{Module,String,Array{Any,1},Int64}, ::String, ::Vararg{String,N} where N; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at ./io.jl:325
 [10] open at ./io.jl:323 [inlined]
 [11] run_code(::Module, ::String, ::String; warn_err::Bool, strip_code::Bool) at /home/rik/FR/src/eval/run.jl:56
 [12] run_code(::Module, ::String, ::String) at /home/rik/FR/src/eval/run.jl:49
 [13] macro expansion at /home/rik/FR/test/eval/run.jl:78 [inlined]
 [14] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Test/src/Test.jl:1115 [inlined]
 [15] top-level scope at /home/rik/FR/test/eval/run.jl:26
 [16] include(::String) at ./client.jl:457
 [17] top-level scope at /home/rik/FR/test/runtests.jl:50
 [18] include(::String) at ./client.jl:457
 [19] top-level scope at none:6
 [20] eval(::Module, ::Any) at ./boot.jl:331
 [21] exec_options(::Base.JLOptions) at ./client.jl:272
 [22] _start() at ./client.jl:506
┌ Franklin Warning: in <input string>
│ There was an error of type 'DomainError' when running a code block.
│ Checking the output files '/tmp/jl_yNUxkV.(out|res)'
│ might be helpful to understand and solve the issue.
│
│ Relevant pointers:
│ - evaluation of Julia code blocks: https://franklinjl.org/code/
└
```

The code is not ready to be merged yet, it needs more testing and possibly a bit of tweaking of the design.