### PR TITLE
Introduce parameters with spaces

### DIFF
--- a/src/parser/html/blocks.jl
+++ b/src/parser/html/blocks.jl
@@ -59,7 +59,14 @@ function qualify_html_hblocks(blocks::Vector{OCBlock})::Vector{AbstractBlock}
             if isnothing(m.captures[2]) || isempty(strip(m.captures[2]))
                 ps = String[]
             else
-                ps = split(m.captures[2])
+                # split parameters such that values in "..." may contain spaces
+                splitregexp = r"([^\s\"']+)|\"([^\"]*)\""
+                ps = SubString.(
+                    m.captures[2],
+                    findall(splitregexp, m.captures[2]; overlap=false),
+                )
+                # strip leading and trailing "
+                ps = strip.(ps,Ref('"'))
             end
             qb[i] = HFun(β.ss, m.captures[1], ps)
             continue

--- a/src/parser/html/blocks.jl
+++ b/src/parser/html/blocks.jl
@@ -59,14 +59,8 @@ function qualify_html_hblocks(blocks::Vector{OCBlock})::Vector{AbstractBlock}
             if isnothing(m.captures[2]) || isempty(strip(m.captures[2]))
                 ps = String[]
             else
-                # split parameters such that values in "..." may contain spaces
-                splitregexp = r"([^\s\"']+)|\"([^\"]*)\""
-                ps = SubString.(
-                    m.captures[2],
-                    findall(splitregexp, m.captures[2]; overlap=false),
-                )
-                # strip leading and trailing "
-                ps = strip.(ps,Ref('"'))
+                # merge \"abc def\" (issue #731)
+                ps = split_hfun_parameters(m.captures[2])
             end
             qb[i] = HFun(β.ss, m.captures[1], ps)
             continue
@@ -93,3 +87,8 @@ Internal function to balance conditional blocks. See [`process_html_qblocks`](@r
 hbalance(::HTML_OPEN_COND) = 1
 hbalance(::HEnd) = -1
 hbalance(::AbstractBlock) = 0
+
+function split_hfun_parameters(s)
+    matches = [e.match for e in eachmatch(HFUN_PARAMS_PAT, s; overlap=false)]
+    return strip.(matches, '\"')
+end

--- a/src/regexes.jl
+++ b/src/regexes.jl
@@ -127,6 +127,14 @@ scope.
 """
 const HBLOCK_FUN_PAT = Regex(HBO * VAR * raw"(\s+((.|\n)*?))?" * HBC)
 
+"""
+    HFUN_PARAMS_PAT
+
+Splits the parameter string of a hfun based on whitespaces but allowing single quoted strings
+with whitespace not to be split.
+"""
+const HFUN_PARAMS_PAT = r"([^\s\"']+)|\"([^\"]*)\""
+
 #= =====================================================
 Pattern checkers
 ===================================================== =#

--- a/test/converter/html/html2.jl
+++ b/test/converter/html/html2.jl
@@ -51,3 +51,15 @@ end
     fhs = F.process_html_qblocks(hs, qblocks)
     @test isapproxstr(fhs, "AEF")
 end
+
+# https://github.com/tlienart/Franklin.jl/issues/731
+@testset "hfun strings" begin
+    a = Franklin.split_hfun_parameters(strip("""
+        "Hello to you" my "julia friends" and "all the others"
+        """))
+    @test a[1] == "Hello to you"
+    @test a[2] == "my"
+    @test a[3] == "julia friends"
+    @test a[4] == "and"
+    @test a[5] == "all the others"
+end


### PR DESCRIPTION
This PR resolves #731, i.e. one can now pass parameters including spaces to an html function by encapsulating it in `"..."`.

To test define
````
function hfun_pcheck(params)
  return """<ul><li>$(join(params,"</li><li>"))</li></ul>"""
end
````

and run in an `.md` file for example
```
{{pcheck abc "abd ref h"}}
```
then you get the following unnumbered list.
<img width="317" alt="Bildschirmfoto 2020-12-13 um 18 33 44" src="https://user-images.githubusercontent.com/115566/102019152-143c6300-3d72-11eb-989a-862ff6a2aae0.png">