### PR TITLE
closes #741 + minor fixes to hfun_redirect

### DIFF
--- a/src/converter/html/functions.jl
+++ b/src/converter/html/functions.jl
@@ -240,7 +240,9 @@ end
 """
 $(SIGNATURES)
 
-H-Function of the form `{{redirect /addr/blah.html}}`.
+H-Function of the form `{{redirect /addr/blah.html}}` or `{{redirect /addr/blah/}}`
+if the last part ends with `/` then `index.html` is appended. Note that the first
+`/` can be omitted.
 """
 function hfun_redirect(params::Vector{String})::String
     # don't put those on the sitemap
@@ -251,6 +253,7 @@ function hfun_redirect(params::Vector{String})::String
                 "address but got $(length(params)). Verify."))
     end
     addr = params[1]
+    addr *= ifelse(addr[end] == '/', "index.html", "")
     if !endswith(addr, ".html")
         throw(HTMLFunctionError("In a {{redirect address}} block the address must be " *
                                 "complete up to the `.html` extension (got '$addr')."))

--- a/src/manager/dir_utils.jl
+++ b/src/manager/dir_utils.jl
@@ -62,6 +62,24 @@ function _out_path(base::String)::String
     return outpath
 end
 
+"""
+$(SIGNATURES)
+
+A user can provide a slug which will then specify the output path.
+There is the underlying assumption that the path will not clash.
+"""
+function form_custom_output_path(slug::String)
+    # a slug is assumed to be `aa` or `aa/bb`
+    # extensions will be ignored, pre and post backslash as well
+    # --> aa/bb.html -> aa/bb (effectively aa/bb/index.html)
+    # --> /aa/bb/cc/ --> aa/bb/cc (effectively aa/bb/cc/index.html)
+    slug = strip(splitext(slug)[1], '/')
+    # form the path
+    p = mkpath(joinpath(path(:site), slug))
+    return joinpath(p, "index.html")
+end
+
+
 _access(p)   = isa(p, Regex) ? p.pattern : p
 _isempty(p)  = isempty(_access(p))
 _endswith(p) = endswith(_access(p), '/')

--- a/src/manager/write_page.jl
+++ b/src/manager/write_page.jl
@@ -75,6 +75,10 @@ without in which case the scaffolding is read from `layout`.
 function write_page(output_path::AS, content::AS;
                     head::T=nothing, pgfoot::T=nothing, foot::T=nothing,
                     )::String where T <: Union{Nothing,AS}
+    slug = locvar(:slug)
+    if !isempty(slug)
+        output_path = form_custom_output_path(slug)
+    end
     # NOTE
     #   - output_path is assumed to exist // see form_output_path
     #   - head/pgfoot/foot === nothing --> read (see franklin.jl)

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -90,6 +90,7 @@ const LOCAL_VARS_DEFAULT = [
     "indented_code" => dpair(false),    # support indented code?
     "tags"          => dpair(String[]),
     "prerender"     => dpair(true),     # allow specific switch
+    "slug"          => dpair(""),       # allow specific target url eg: aa/bb/cc
     # -----------------
     # TABLE OF CONTENTS
     "mintoclevel" => dpair(1),   # set to 2 to ignore h1


### PR DESCRIPTION
This allows the following:

```
@def slug = "foo/bar"
```

which will mean that the page will be available at `base_url/prepath/foo/bar/` (i.e. the page will be actually written to `base_url/prepath/foo/bar/index.html` 

cc @kdheepak 

There's also a small improvement to redirect, before we had to write the full URL but now you can write:

```
{{redirect foo/bar/}}
```

to mean `{{redirect foo/bar/index.html}}`; 

The previous

```
{{redirect my/old/url.html}}
```

remains valid