### PR TITLE
fixes for Utils, closes #756

### DIFF
--- a/src/Franklin.jl
+++ b/src/Franklin.jl
@@ -84,7 +84,14 @@ const FD_ENV = LittleDict(
     :SILENT_MODE   => false,
     :QUIET_TEST    => false,
     :SHOW_WARNINGS => true,     # franklin-specific warnings
+    :UTILS_COUNTER => 0,        # counter for utils module
+    :UTILS_HASH    => nothing   # hash of the utils
     )
+
+utils_name()   = "Utils_$(FD_ENV[:UTILS_COUNTER])"
+utils_symb()   = Symbol(utils_name())
+utils_module() = getproperty(Main, utils_symb())
+utils_hash()   = nothing
 
 # keep track of pages which need to be re-evaluated after the full-pass
 # to ensure that their h-fun are working with the fully-defined scope

--- a/src/converter/html/blocks.jl
+++ b/src/converter/html/blocks.jl
@@ -171,7 +171,7 @@ function process_html_for(hs::AS, qblocks::Vector{AbstractBlock},
                              "Please make sure it's defined."))
     end
     if iname ∈ UTILS_NAMES # can only happen if Utils is defined.
-        iter = getfield(Main.Utils, Symbol(iname))
+        iter = getfield(utils_module(), Symbol(iname))
     else
         iter = locvar(iname)
     end

--- a/src/converter/html/functions.jl
+++ b/src/converter/html/functions.jl
@@ -8,10 +8,10 @@ function convert_html_fblock(β::HFun)::String
     fun = Symbol("hfun_" * lowercase(β.fname))
     ex  = isempty(β.params) ? :($fun()) : :($fun($β.params))
     # see if a hfun was defined in utils
-    if isdefined(Main, :Utils) && isdefined(Main.Utils, fun)
+    if isdefined(Main, utils_symb()) && isdefined(utils_module(), fun)
         # skip eval if the page is delayed
         isdelayed() && return ""
-        res = Core.eval(Main.Utils, ex)
+        res = Core.eval(utils_module(), ex)
         return string(res)
     end
     # see if a hfun was defined internally
@@ -53,7 +53,7 @@ function hfun_fill(params::Vector{String})::String
     vname = params[1]
     if length(params) == 1
         if vname in UTILS_NAMES
-            repl = string(getfield(Main.Utils, Symbol(vname)))
+            repl = string(getfield(utils_module(), Symbol(vname)))
         else
             tmp_repl = locvar(vname)
             if isnothing(tmp_repl)

--- a/src/converter/latex/latex.jl
+++ b/src/converter/latex/latex.jl
@@ -34,8 +34,8 @@ function resolve_lxobj(lxo::LxObj, lxdefs::Vector{LxDef};
     # it will be `nothing` in math mode or when defined in utils
     if isnothing(lxd)
         # check if it's defined in Utils and act accordingly
-        if isdefined(Main, :Utils) && isdefined(Main.Utils, fun)
-            raw = Core.eval(Main.Utils, :($fun($lxo, $lxdefs)))
+        if isdefined(Main, utils_symb()) && isdefined(utils_module(), fun)
+            raw = Core.eval(utils_module(), :($fun($lxo, $lxdefs)))
             return reprocess(raw, lxdefs)
         else
             # let the math backend deal with the string

--- a/src/eval/codeblock.jl
+++ b/src/eval/codeblock.jl
@@ -124,8 +124,8 @@ function resolve_code_block(ss::SubString; shortcut=false)::String
         # >> eval the code in the relevant module (this creates output/)
         res = run_code(mod, code, cp.out_path; strip_code=false)
         # >> write res to file
-        # >> this weird thing is to make sure that the proper "show"
-        #    is called...
+        # >> this weird thing with QuoteNode is to make sure that the proper
+        #    "show" method is called...
         io = IOBuffer()
         Core.eval(mod, quote show($(io), "text/plain", $(QuoteNode(res))) end)
         write(cp.res_path, take!(io))

--- a/src/eval/module.jl
+++ b/src/eval/module.jl
@@ -31,6 +31,7 @@ happen. Return a handle pointing to the module.
 function newmodule(name::String)::Module
     mod  = nothing
     junk = tempname()
+
     open(junk, "w") do outf
         # discard the "WARNING: redefining module X"
         redirect_stderr(outf) do
@@ -40,9 +41,10 @@ function newmodule(name::String)::Module
                     import Franklin: @OUTPUT, @delay, fdplotly,
                                      locvar, pagevar, globvar,
                                      fd2html, get_url
-                    if isdefined(Main, :Utils) && typeof(Main.Utils) == Module
-                        import ..Utils
-                    end
+                    """ * ifelse(startswith(name, "Utils"), "",
+                            ifelse(FD_ENV[:UTILS_HASH] === nothing, "", """
+                    import $(Franklin.utils_name())
+                    """)) * """
                     using Dates
                 end
                 """))

--- a/src/manager/dir_utils.jl
+++ b/src/manager/dir_utils.jl
@@ -150,6 +150,8 @@ function _scan_input_dir!(other_files::TrackedFiles,
             else
                 if file == "config.md"
                     add_if_new_file!(infra_files, opts...)
+                elseif file == "utils.jl"
+                    add_if_new_file!(infra_files, opts...)                    
                 elseif fext == ".md"
                     add_if_new_file!(md_pages, opts...)
                 elseif fext ∈ (".html", ".htm")

--- a/src/manager/franklin.jl
+++ b/src/manager/franklin.jl
@@ -321,9 +321,6 @@ function fd_loop(cycle_counter::Int, ::LiveServer.FileWatcher,
             verb && print(fmsg)
             dict[fpair] = cur_t
 
-            # Reprocess utils.jl in Utils module
-            process_utils()
-
             # if it's an infra_file trigger a fullpass as potentially
             # the whole website depends upon it (e.g. CSS)
             if haskey(watched_files[:infra], fpair)

--- a/src/parser/latex/blocks.jl
+++ b/src/parser/latex/blocks.jl
@@ -162,11 +162,11 @@ function get_lxdef_ref(lxname::SubString, lxdefs::Vector{LxDef},
     #  3. throw an error
     if isempty(ks)
         # check if defined in utils
-        if isdefined(Main, :Utils)
+        if isdefined(Main, utils_symb())
             # env def 'env_***'
-            flag = isenv && isdefined(Main.Utils, Symbol("env_$(lxname)"))
+            flag = isenv && isdefined(utils_module(), Symbol("env_$(lxname)"))
             # com def 'lx_***'
-            flag |= isdefined(Main.Utils, Symbol("lx_$(lxname[2:end])"))
+            flag |= isdefined(utils_module(), Symbol("lx_$(lxname[2:end])"))
             flag && return (Ref(nothing), true)
         end
         # if we're here, and in math mode, let the math engine deal with it

--- a/src/parser/tokens.jl
+++ b/src/parser/tokens.jl
@@ -113,7 +113,7 @@ function envname(τ::Token)
     m = match(LX_ENVNAME_PAT, τ.ss)
     isnothing(m) || return m.captures[1]
     throw(LxObjError("""
-        In the context of trying to find environments, an isuse was met, possibly one of the
+        In the context of trying to find environments, an issue was met, possibly one of the
         delimiter is malformed, check that all your environment blocks are delimited by
         `\begin{somename}` and `\end{somename}`."""))
 end

--- a/src/regexes.jl
+++ b/src/regexes.jl
@@ -12,7 +12,7 @@ block. For example:
 
 will give as first capture group `\\com`.
 """
-const LX_NAME_PAT = r"^\s*(\\?\p{L}+\*?)\s*$"
+const LX_NAME_PAT = r"^\s*(\\?\p{L}[\p{L}_]*\*?)\s*$"
 
 """
 LX_NARG_PAT
@@ -33,7 +33,7 @@ LX_ENVNAME_PAT
 
 Regex to find the name in a LX_BEGIN or LX_END.
 """
-const LX_ENVNAME_PAT = r"\\(?:begin|end)\{\s*(\p{L}+\*?)\s*\}"
+const LX_ENVNAME_PAT = r"\\(?:begin|end)\{\s*(\p{L}[\p{L}_]*\*?)\s*\}"
 
 #= =====================================================
 MDDEF patterns


### PR DESCRIPTION
There was some pretty sneaky stuff going on at the interplay between FranklinUtils and Franklin; essentially declaring environments (begin-end) via a macro caused troubles when utils was updated and the new definition would not be used.

Unfortunately I didn't find a neat fix to this, in the meantime, the Utils are now evaluated in a new temp module every time the file is refreshed, this guarantees that the latest version of whatever is defined in there is always used and allows the use of the `@env` macro from `FranklinUtils` which is pretty useful.

To really do this cleanly I'd need to fully understand where stuff are evaluated with macros and `ExprTools` and I don't have the time for that now :( 