### PR TITLE
Add `keep_path` global variable (#759)

### DIFF
--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -32,6 +32,8 @@ const GLOBAL_VARS_DEFAULT = [
     "tag_page_path"    => dpair("tag"),
     # will be added to IGNORE_FILES
     "ignore"           => Pair(String[], (Vector{Any},)),
+    # don't insert `index.html` at the end of the path for these files
+    "keep_path"        => Pair(String[], (Vector{String},)),
     # for robots.txt
     "robots_disallow"  => Pair(String[], (Vector{String},)),
     "generate_robots"  => dpair(true),


### PR DESCRIPTION
in `config.md` users can now define `keep_path` as a list of things they don't want Franklin to modify the path to (see #759 for context)

```
@def keep_path = ["foo.html", "bar/baz/"]
```

what that will do is:

* the file `<folder>/foo.html` will be copied to `<folder>/__site/foo.html` (no injection of `index.html`)
* the files in `<folder>/bar/baz/` will be copied to `<folder>/__site/bar/baz/` without injection of `index.html`

this also works for `.md` files btw so

* the file `<folder>/foo.md` with this setting will be made available at `<domain>/foo.html` and not at the default `<domain>/foo/index.html` (ie `<domain>/foo/`)

@ViralBShah I'll merge this in master now, and will release it once you've had a chance to play with it; hopefully it should just work.