### PR TITLE
rethrow persists the original stacktrace

### DIFF
--- a/src/manager/file_utils.jl
+++ b/src/manager/file_utils.jl
@@ -85,7 +85,7 @@ function process_file(case::Symbol, fpair::Pair{String,String}, args...)::Int
                 $err
                 """)
         end
-        FD_ENV[:SUPPRESS_ERR] || throw(err)
+        FD_ENV[:SUPPRESS_ERR] || rethrow()
         return -1
     end
     return 0


### PR DESCRIPTION
using `throw(err)` displays a stackstrace from the point at which that `throw` occcurs, making it diffucult to pinpoint the original error. The `rethrow`  function is meant for exactly this use case. 

*Before* 
```
┌ Franklin Warning: in <schedule.md>
│ Encountered an issue processing 'schedule.md' in ww.juliacon.org\2020.
│ Verify, then re-start the Franklin server.
│ The error is displayed below:
│ ErrorException("type Nothing has no field captures")
└
ERROR: type Nothing has no field captures
Stacktrace:
 [1] process_file(::Symbol, ::Pair{String,String}, ::String, ::Vararg{Any,N} where N) at \.julia\packages\Franklin\X69Nd\src\manager\file_utils.jl:88
 [2] fd_fullpass(::NamedTuple{(:other, :infra, :md, :html, :literate),NTuple{5,Dict{Pair{String,String},Float64}}}) at \.julia\packages\Franklin\X69Nd\src\manager\franklin.jl:240
 [3] serve(; clear::Bool, verb::Bool, port::Int64, single::Bool, prerender::Bool, nomess::Bool, is_final_pass::Bool, no_fail_prerender::Bool, eval_all::Bool, silent::Bool, cleanup::Bool, on_write::Franklin.var"#231#234", log::Bool, host::String, show_warnings::Bool, launch::Bool) at \.julia\packages\Franklin\X69Nd\src\manager\franklin.jl:118
 [4] serve() at \.julia\packages\Franklin\X69Nd\src\manager\franklin.jl:66
 [5] top-level scope at REPL[3]:1
```

*After*

```
┌ Franklin Warning: in <schedule.md>
│ Encountered an issue processing 'schedule.md' in ww.juliacon.org\2020.
│ Verify, then re-start the Franklin server.
│ The error is displayed below:
│ ErrorException("type Nothing has no field captures")
└
ERROR: type Nothing has no field captures
Stacktrace:
 [1] getproperty(::Nothing, ::Symbol) at .\Base.jl:33
 [2] curyear() at utils.jl:35
 [3] hfun_curyear() at utils.jl:38
 [4] top-level scope at none:1
```

Note how the original stacktrace is pointing to `file_utils.jl:88` which is where the error is re-thrown. The original error happens in `curyear() at utils.jl:35` which is shown only after this change. 