### PR TITLE
Linkclass

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.10.29"
+version = "0.10.30"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/converter/markdown/blocks.jl
+++ b/src/converter/markdown/blocks.jl
@@ -134,7 +134,9 @@ function convert_header(β::OCBlock, lxdefs::Vector{LxDef})::String
         PAGE_HEADERS[rstitle] = (title, 1, parse(Int, hk[2]))
     end
     # return the title
-    return html_hk(hk, html_ahref_key(rstitle, title); id=rstitle)
+    return html_hk(hk, html_ahref_key(rstitle, title;
+                                      class=locvar(:header_anchor_class)::String),
+                   id=rstitle)
 end
 
 """

--- a/src/utils/html.jl
+++ b/src/utils/html.jl
@@ -6,7 +6,7 @@ html_sup(id::String, in::AS) = "<sup id=\"$id\">$in</sup>"
 
 """Convenience function for a header."""
 html_hk(hk::String, t::AS; id::String="", class::String="") =
-    "<$hk$(attr(:id, id))>$t</$hk>"
+    "<$hk$(attr(:id, id))$(attr(:class, class))>$t</$hk>"
 
 """Convenience function for content tagging (see `build_page`)"""
 html_content(tag::String, content::AS; class::String, id::String) =
@@ -27,7 +27,7 @@ end
 
 Convenience function to introduce a hyper reference relative to a key.
 """
-html_ahref_key(k::AS, n::Union{Int,AS}) = html_ahref("#$k", n)
+html_ahref_key(k::AS, n::Union{Int,AS}; class="") = html_ahref("#$k", n; class=class)
 
 """
     html_div

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -103,6 +103,9 @@ const LOCAL_VARS_DEFAULT = [
     "showall"       => dpair(false),  # if true, notebook style
     "fd_eval"       => dpair(false),  # toggle re-eval
     # ------------------
+    # header links class
+    "header_anchor_class" => dpair("header-anchor"),
+    # ------------------
     # RSS 2.0 specs [^2]
     "rss"             => dpair(""),
     "rss_description" => dpair(""),

--- a/test/converter/md/markdown.jl
+++ b/test/converter/md/markdown.jl
@@ -63,8 +63,8 @@ end
         done
         """ |> seval
     @test h // """
-        <h1 id="title"><a href="#title">Title</a></h1>
+        <h1 id="title"><a href="#title" class="header-anchor">Title</a></h1>
         <p>and then</p>
-        <h2 id="subtitle_cool"><a href="#subtitle_cool">Subtitle cool&#33;</a></h2>
+        <h2 id="subtitle_cool"><a href="#subtitle_cool" class="header-anchor">Subtitle cool&#33;</a></h2>
         <p>done</p>"""
 end

--- a/test/converter/md/markdown2.jl
+++ b/test/converter/md/markdown2.jl
@@ -41,20 +41,23 @@ end
     @test isapproxstr(h, raw"""
         <div class="franklin-toc">
           <ol>
-            <li>
-              <a href="#hello_fd">Hello <code>fd</code></a>
+            <li><a href="#hello_fd">Hello <code>fd</code></a>
               <ol>
-                <li><ol><li><a href="#weirdly_nested">weirdly nested</a></li></ol></li>
+                <li>
+                  <ol>
+                    <li><a href="#weirdly_nested">weirdly nested</a></li>
+                  </ol>
+                </li>
                 <li><a href="#goodbye">Goodbye&#33;</a></li>
               </ol>
             </li>
             <li><a href="#done">Done</a></li>
           </ol>
         </div>
-        <h2 id="hello_fd"><a href="#hello_fd">Hello <code>fd</code></a></h2>
-        <h4 id="weirdly_nested"><a href="#weirdly_nested">weirdly nested</a></h4>
-        <h3 id="goodbye"><a href="#goodbye">Goodbye&#33;</a></h3>
-        <h2 id="done"><a href="#done">Done</a></h2>
+        <h2 id="hello_fd"><a href="#hello_fd" class="header-anchor">Hello <code>fd</code></a></h2>
+        <h4 id="weirdly_nested"><a href="#weirdly_nested" class="header-anchor">weirdly nested</a></h4>
+        <h3 id="goodbye"><a href="#goodbye" class="header-anchor">Goodbye&#33;</a></h3>
+        <h2 id="done"><a href="#done" class="header-anchor">Done</a></h2>
         <p>done.</p>
         """)
 end
@@ -89,12 +92,12 @@ end
                 </li>
             </ol>
         </div>
-        <h1 id="a"><a href="#a">A</a></h1>
-        <h2 id="b"><a href="#b">B</a></h2>
-        <h4 id="c"><a href="#c">C</a></h4>
-        <h3 id="d"><a href="#d">D</a></h3>
-        <h2 id="e"><a href="#e">E</a></h2>
-        <h3 id="f"><a href="#f">F</a></h3>
+        <h1 id="a"><a href="#a" class="header-anchor">A</a></h1>
+        <h2 id="b"><a href="#b" class="header-anchor">B</a></h2>
+        <h4 id="c"><a href="#c" class="header-anchor">C</a></h4>
+        <h3 id="d"><a href="#d" class="header-anchor">D</a></h3>
+        <h2 id="e"><a href="#e" class="header-anchor">E</a></h2>
+        <h3 id="f"><a href="#f" class="header-anchor">F</a></h3>
         <p>done.</p>
         """)
 end

--- a/test/coverage/extras1.jl
+++ b/test/coverage/extras1.jl
@@ -96,6 +96,7 @@ end
         ## Goodbye
         """ |> fd2html_td
     @test isapproxstr(s, raw"""
-<div class="franklin-toc"><ol><li><a href="#hello">Hello</a><ol><li><a href="#goodbye">Goodbye</a></li></ol></li></ol></div>
- <h1 id="hello"><a href="#hello">Hello</a></h1>  <h2 id="goodbye"><a href="#goodbye">Goodbye</a></h2>""")
+        <div class="franklin-toc"><ol><li><a href="#hello">Hello</a><ol><li><a href="#goodbye">Goodbye</a></li></ol></li></ol></div>
+        <h1 id="hello"><a href="#hello" class="header-anchor">Hello</a></h1>
+        <h2 id="goodbye"><a href="#goodbye" class="header-anchor">Goodbye</a></h2>""")
 end

--- a/test/global/cases2.jl
+++ b/test/global/cases2.jl
@@ -78,9 +78,10 @@ end
 
     if VERSION >= v"1.4.0-"
         @test isapproxstr(st |> seval, raw"""<p>A</p>
-<h3 id="title"><a href="#title">Title</a></h3>
-<table><tr><th align="center">No.</th><th align="center">Graph</th><th align="center">Vertices</th><th align="center">Edges</th></tr><tr><td align="center">1</td><td align="center">Twitter Social Circles</td><td align="center">81,306</td><td align="center">1,342,310</td></tr><tr><td align="center">2</td><td align="center">Astro-Physics Collaboration</td><td align="center">17,903</td><td align="center">197,031</td></tr><tr><td align="center">3</td><td align="center">Facebook Social Circles</td><td align="center">4,039</td><td align="center">88,234</td></tr></table>
-<p>C</p>""")
+            <h3 id="title"><a href="#title" class="header-anchor">Title</a></h3>
+
+            <table><tr><th align="center">No.</th><th align="center">Graph</th><th align="center">Vertices</th><th align="center">Edges</th></tr><tr><td align="center">1</td><td align="center">Twitter Social Circles</td><td align="center">81,306</td><td align="center">1,342,310</td></tr><tr><td align="center">2</td><td align="center">Astro-Physics Collaboration</td><td align="center">17,903</td><td align="center">197,031</td></tr><tr><td align="center">3</td><td align="center">Facebook Social Circles</td><td align="center">4,039</td><td align="center">88,234</td></tr></table>
+            <p>C</p>""")
     else
         @test isapproxstr(st |> seval, raw""" <p>A</p>
             <h3 id="title"><a href="#title">Title</a></h3>
@@ -112,7 +113,7 @@ end
     etc
     ~~~{{fill title}}~~~
     """ |> fd2html_td
-    @test isapproxstr(s, raw"""<h1 id="aaa"><a href="#aaa">AAA</a></h1>  <p>etc AAA</p>""")
+    @test isapproxstr(s, raw"""<h1 id="aaa"><a href="#aaa" class="header-anchor">AAA</a></h1>  <p>etc AAA</p>""")
 end
 
 @testset "i 430" begin

--- a/test/global/cases2.jl
+++ b/test/global/cases2.jl
@@ -82,27 +82,6 @@ end
 
             <table><tr><th align="center">No.</th><th align="center">Graph</th><th align="center">Vertices</th><th align="center">Edges</th></tr><tr><td align="center">1</td><td align="center">Twitter Social Circles</td><td align="center">81,306</td><td align="center">1,342,310</td></tr><tr><td align="center">2</td><td align="center">Astro-Physics Collaboration</td><td align="center">17,903</td><td align="center">197,031</td></tr><tr><td align="center">3</td><td align="center">Facebook Social Circles</td><td align="center">4,039</td><td align="center">88,234</td></tr></table>
             <p>C</p>""")
-    else
-        @test isapproxstr(st |> seval, raw""" <p>A</p>
-            <h3 id="title"><a href="#title">Title</a></h3>
-
-            <table>
-              <tr>
-                <th>No.</th><th>Graph</th><th>Vertices</th><th>Edges</th>
-              </tr>
-              <tr>
-                <td>1</td><td>Twitter Social Circles</td><td>81,306</td><td>1,342,310</td>
-              </tr>
-              <tr>
-                <td>2</td><td>Astro-Physics Collaboration</td><td>17,903</td><td>197,031</td>
-              </tr>
-              <tr>
-                <td>3</td><td>Facebook Social Circles</td><td>4,039</td><td>88,234</td>
-              </tr>
-            </table>
-
-            <p>C</p>
-            """)
     end
 end
 

--- a/test/html/closep.jl
+++ b/test/html/closep.jl
@@ -32,7 +32,7 @@ F.def_GLOBAL_VARS!()
     """ |> fd2html
     @test h // """
         <p>A</p>
-        <h1 id="h"><a href="#h">H</a></h1>
+        <h1 id="h"><a href="#h" class="header-anchor">H</a></h1>
         <p>B</p>"""
     h = """
     A
@@ -44,10 +44,10 @@ F.def_GLOBAL_VARS!()
     """ |> fd2html
     @test h // """
         <p>A</p>
-        <h1 id="h1"><a href="#h1">H1</a></h1>
-        <h2 id="h2"><a href="#h2">H2</a></h2>
+        <h1 id="h1"><a href="#h1" class="header-anchor">H1</a></h1>
+        <h2 id="h2"><a href="#h2" class="header-anchor">H2</a></h2>
         <p>B</p>
-        <h2 id="h2__2"><a href="#h2__2">H2</a></h2>
+        <h2 id="h2__2"><a href="#h2__2" class="header-anchor">H2</a></h2>
         <p>C</p>"""
 end
 

--- a/test/integration/literate.jl
+++ b/test/integration/literate.jl
@@ -90,7 +90,7 @@ end
         \literate{/_literate/tutorial.jl}
         """ |> fd2html_td
     @test isapproxstr(h, """
-        <h1 id="rational_numbers"><a href="#rational_numbers">Rational numbers</a></h1>
+        <h1 id="rational_numbers"><a href="#rational_numbers" class="header-anchor">Rational numbers</a></h1>
         <p>In julia rational numbers can be constructed with the <code>//</code> operator. Lets define two rational numbers, <code>x</code> and <code>y</code>:</p>
         <pre><code class="language-julia">$(F.htmlesc(raw"""
             # Define variable x and y
@@ -141,7 +141,7 @@ end
         \literate{/_literate/tutorial.jl}
         """ |> fd2html_td
     @test h // """
-        <h1 id="rational_numbers"><a href="#rational_numbers">Rational numbers</a></h1>
+        <h1 id="rational_numbers"><a href="#rational_numbers" class="header-anchor">Rational numbers</a></h1>
         <pre><code class="language-julia">$(F.htmlesc(raw"""const a = 1"""))</code></pre>
         <pre><code class="language-julia">$(F.htmlesc(raw"""a = 5"""))</code></pre><pre><code class="plaintext">5</code></pre>
         """

--- a/test/latex/newcommand.jl
+++ b/test/latex/newcommand.jl
@@ -177,7 +177,7 @@ end
     @test isapproxstr(s, raw"""
         ⭒A⭒
         <p>then some</p>
-        <h2 id="blah"><a href="#blah">blah </a></h2>
+        <h2 id="blah"><a href="#blah" class="header-anchor">blah </a></h2>
         <p>end ⭒B⭒.</p>
         """)
 end

--- a/test/parser/markdown+latex.jl
+++ b/test/parser/markdown+latex.jl
@@ -108,17 +108,17 @@ end
         6
         """ |> seval
     @test isapproxstr(h, """
-        <h1 id="t1"><a href="#t1">t1</a></h1>
+        <h1 id="t1"><a href="#t1" class="header-anchor">t1</a></h1>
         <p>1</p>
-        <h2 id="t2"><a href="#t2">t2</a></h2>
+        <h2 id="t2"><a href="#t2" class="header-anchor">t2</a></h2>
         <p>2</p>
-        <h2 id="t3_blah_etc"><a href="#t3_blah_etc">t3 <code>blah</code> etc</a></h2>
+        <h2 id="t3_blah_etc"><a href="#t3_blah_etc" class="header-anchor">t3 <code>blah</code> etc</a></h2>
         <p>3</p>
-        <h3 id="t4"><a href="#t4">t4 </a></h3>
+        <h3 id="t4"><a href="#t4" class="header-anchor">t4 </a></h3>
         <p>4</p>
-        <h3 id="t2__2"><a href="#t2__2">t2</a></h3>
+        <h3 id="t2__2"><a href="#t2__2" class="header-anchor">t2</a></h3>
         <p>5</p>
-        <h3 id="t2__3"><a href="#t2__3">t2</a></h3>
+        <h3 id="t2__3"><a href="#t2__3" class="header-anchor">t2</a></h3>
         <p>6</p>
         """)
 
@@ -132,11 +132,11 @@ end
         C
         """ |> seval
     @test  isapproxstr(h, """
-        <h2 id="example"><a href="#example">example</a></h2>
+        <h2 id="example"><a href="#example" class="header-anchor">example</a></h2>
         <p>A</p>
-        <h2 id="example__2"><a href="#example__2">example</a></h2>
+        <h2 id="example__2"><a href="#example__2" class="header-anchor">example</a></h2>
         <p>B</p>
-        <h2 id="example_2"><a href="#example_2">example 2</a></h2>
+        <h2 id="example_2"><a href="#example_2" class="header-anchor">example 2</a></h2>
         <p>C</p>
         """)
 end
@@ -150,14 +150,14 @@ end
 
 @testset "Header+lx" begin
     h = "# blah" |> fd2html_td
-    @test h // """<h1 id="blah"><a href="#blah">blah</a></h1>"""
+    @test h // """<h1 id="blah"><a href="#blah" class="header-anchor">blah</a></h1>"""
     h = raw"""
         \newcommand{\foo}{foo}
         \newcommand{\header}{# hello}
         \foo
         \header
         """ |> fd2html_td
-    @test h // """<p>foo <h1 id="hello"><a href="#hello">hello</a></h1></p>"""
+    @test h // """<p>foo <h1 id="hello"><a href="#hello" class="header-anchor">hello</a></h1></p>"""
     h = raw"""
         \newcommand{\foo}{foo}
         \foo hello
@@ -167,11 +167,11 @@ end
         \newcommand{\foo}{blah}
         # \foo hello
         """ |> fd2html_td
-    @test h // """<h1 id="blah_hello"><a href="#blah_hello">blah hello</a></h1>"""
+    @test h // """<h1 id="blah_hello"><a href="#blah_hello" class="header-anchor">blah hello</a></h1>"""
     h = raw"""
         \newcommand{\foo}{foo}
         \newcommand{\header}[2]{!#1 \foo #2}
         \header{##}{hello}
         """ |> fd2html_td
-    @test h // """<h2 id="foo_hello"><a href="#foo_hello">foo  hello</a></h2>"""
+    @test h // """<h2 id="foo_hello"><a href="#foo_hello" class="header-anchor">foo  hello</a></h2>"""
 end


### PR DESCRIPTION
All headers in Franklin are links, they're now links with the default class `class="header-anchor"`.

If you want to change this (or remove it), just set the page variable `header_anchor_class` to `""` or to `"your-header-class"`. 

cc: @lucaferranti

I'll merge this in master soon and do a patch release with it so you can use it for JuliaIntervals. Do let me know if it doesn't work then for the fix top fix.