### PR TITLE
a couple of missed _html_parts

### DIFF
--- a/docs/extras/lunr.md
+++ b/docs/extras/lunr.md
@@ -64,7 +64,7 @@ The file `lunrclient.js` (and its minified version) does the following:
 You might want to modify the `parseLunrResults` if you want the results to be  displayed differently.
 
 \note{
-    If you modify this file, make sure it's called properly in the `src/_html_parts/index.html` and, eventually, [minify it](https://jscompress.com/).  
+    If you modify this file, make sure it's called properly in the `_layout/index.html` and, eventually, [minify it](https://jscompress.com/).  
 }
 
 ## Adding a search box

--- a/docs/styling/templates.md
+++ b/docs/styling/templates.md
@@ -41,7 +41,7 @@ We will need to provide the appropriate stylesheet in `_css/` and adjust the lay
 
 ### Adapting the head and foot
 
-The file `_html_parts/head.html` is the most important one you will have to adjust.
+The file `_layout/head.html` is the most important one you will have to adjust.
 
 Let us first change the name of the main stylesheet `_css/basic.css` to `_css/jemdoc.css` which is more appropriate.
 The reference to the stylesheet in `head.html` consequently has to be changed to mention `jemdoc.css` instead of `basic.css`:


### PR DESCRIPTION
Found these while trying to set up a new site.

There are also two instances of `_html_parts` remaining in `docs/_libs/lunr/lunr_index.js`, but I didn't want to edit those by hand since I've no idea how it's generated.