### PR TITLE
Update highlight.js call in prerender to use highlight 10.7.0

### DIFF
--- a/src/converter/html/prerender.jl
+++ b/src/converter/html/prerender.jl
@@ -68,7 +68,7 @@ function js_prerender_highlight(hs::String)::String
         # un-escape code string
         cs = html_unescape(cs) |> escape_string
         # add to content of jsbuffer
-        write(jsbuffer, """console.log("<pre><code class=\\"$lang hljs\\">" + hljs.highlight("$lang", "$cs").value + "</code></pre>");""")
+        write(jsbuffer, """console.log("<pre><code class=\\"$lang hljs\\">" + hljs.highlight("$cs", {'language': "$lang"}).value + "</code></pre>");""")
         # in between every block, write $splitter so that output can be split easily
         i == length(matches)-1 || write(jsbuffer, """console.log('$splitter');""")
     end


### PR DESCRIPTION
Closes #803

Before
![before](https://user-images.githubusercontent.com/1068752/112382762-067c6f00-8ccb-11eb-9b93-9558ed0789ce.jpg)

After
![after](https://user-images.githubusercontent.com/1068752/112382759-054b4200-8ccb-11eb-92db-0f05db6e99fc.jpg)
