### PR TITLE
Add option to pass default value to pagevar

### DIFF
--- a/docs/syntax/utils.md
+++ b/docs/syntax/utils.md
@@ -84,7 +84,7 @@ function hfun_bar(params)
 end
 ```
 
-Note that all functions defined in `utils.jl` can call `locvar(name)` and `globvar(name)` to retrieve the value associated with a local or global page variable by its name; for instance `locvar("author")`.
+Note that all functions defined in `utils.jl` can call `locvar(name)` and `globvar(name)` to retrieve the value associated with a local or global page variable by its name; for instance `locvar("author")`. You may optionally pass a `default` argument that will be returned instead of `nothing` if the variable does not exist, eg `locvar(name; default="Not named")`.
 
 ## "LaTeX" functions (`lx_*`)
 

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -219,7 +219,7 @@ The keys don't have the file extension so `"blog/pg1" => PageVars`.
 const ALL_PAGE_VARS = LittleDict{String,PageVars}()
 
 """
-    pagevar(rpath, name)
+    pagevar(rpath, name, default)
 
 Convenience function to get the value associated with a var available to a page
 corresponding to `rpath`. So for instance if `blog/index.md` has `@def var = 0`
@@ -227,8 +227,11 @@ then this can be accessed with `pagevar("blog/index", "var")` or
 `pagevar("blog/index.md", "var")`.
 If `rpath` is not yet a key of `ALL_PAGE_VARS` then maybe the page hasn't been
 processed yet so force a pass over that page.
+
+Optional: pass a third argument that will be returned instead of `nothing`
+if the var does not exist.
 """
-function pagevar(rpath::AS, name::Union{Symbol,String})
+function pagevar(rpath::AS, name::Union{Symbol,String}, default=nothing)
     # only split extension if it's .md or .html (otherwise can cause trouble
     # if there's a dot in the page name... not recommended but happens.)
     rpc = splitext(rpath)
@@ -267,7 +270,7 @@ function pagevar(rpath::AS, name::Union{Symbol,String})
         end
     end
     name = String(name)
-    haskey(ALL_PAGE_VARS[rpath], name) || return nothing
+    haskey(ALL_PAGE_VARS[rpath], name) || return default
     return ALL_PAGE_VARS[rpath][name].first
 end
 

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -205,7 +205,7 @@ end
 Convenience function to get the value associated with a global var.
 Return `default` (which is `nothing` if not specified) if the variable is not found.
 """
-function globvar(name::Union{Symbol,String})
+function globvar(name::Union{Symbol,String}; default=nothing)
     name = String(name)
     return get(GLOBAL_VARS, name, default)
 end

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -189,25 +189,25 @@ function def_LOCAL_VARS!()::Nothing
 end
 
 """
-    locvar(name)
+    locvar(name; default=nothing)
 
 Convenience function to get the value associated with a local var.
-Return `nothing` if the variable is not found.
+Return `default` (which is `nothing` if not specified) if the variable is not found.
 """
-function locvar(name::Union{Symbol,String})
+function locvar(name::Union{Symbol,String}; default=nothing)
     name = String(name)
-    return haskey(LOCAL_VARS, name) ? LOCAL_VARS[name].first : nothing
+    return ifelse(haskey(LOCAL_VARS, name), LOCAL_VARS[name].first, default)
 end
 
 """
-    globvar(name)
+    globvar(name; default=nothing)
 
 Convenience function to get the value associated with a global var.
-Return `nothing` if the variable is not found.
+Return `default` (which is `nothing` if not specified) if the variable is not found.
 """
 function globvar(name::Union{Symbol,String})
     name = String(name)
-    return haskey(GLOBAL_VARS, name) ? GLOBAL_VARS[name].first : nothing
+    return get(GLOBAL_VARS, name, default)
 end
 
 
@@ -219,7 +219,7 @@ The keys don't have the file extension so `"blog/pg1" => PageVars`.
 const ALL_PAGE_VARS = LittleDict{String,PageVars}()
 
 """
-    pagevar(rpath, name, default)
+    pagevar(rpath, name; default=nothing)
 
 Convenience function to get the value associated with a var available to a page
 corresponding to `rpath`. So for instance if `blog/index.md` has `@def var = 0`
@@ -228,8 +228,7 @@ then this can be accessed with `pagevar("blog/index", "var")` or
 If `rpath` is not yet a key of `ALL_PAGE_VARS` then maybe the page hasn't been
 processed yet so force a pass over that page.
 
-Optional: pass a third argument that will be returned instead of `nothing`
-if the var does not exist.
+Return `default` (which is `nothing` if not specified) if the variable is not found.
 """
 function pagevar(rpath::AS, name::Union{Symbol,String}, default=nothing)
     # only split extension if it's .md or .html (otherwise can cause trouble

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -269,7 +269,7 @@ function pagevar(rpath::AS, name::Union{Symbol,String}; default=nothing)
         end
     end
     name = String(name)
-    return ifelse(haskey(ALL_PAGE_VARS[rpath], name), ALL_PAGE_VARS[rpath][name].first, default)
+    return haskey(ALL_PAGE_VARS[rpath], name) ? ALL_PAGE_VARS[rpath][name].first : default
 end
 
 """

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -230,7 +230,7 @@ processed yet so force a pass over that page.
 
 Return `default` (which is `nothing` if not specified) if the variable is not found.
 """
-function pagevar(rpath::AS, name::Union{Symbol,String}, default=nothing)
+function pagevar(rpath::AS, name::Union{Symbol,String}; default=nothing)
     # only split extension if it's .md or .html (otherwise can cause trouble
     # if there's a dot in the page name... not recommended but happens.)
     rpc = splitext(rpath)
@@ -269,8 +269,7 @@ function pagevar(rpath::AS, name::Union{Symbol,String}, default=nothing)
         end
     end
     name = String(name)
-    haskey(ALL_PAGE_VARS[rpath], name) || return default
-    return ALL_PAGE_VARS[rpath][name].first
+    return ifelse(haskey(ALL_PAGE_VARS[rpath], name), ALL_PAGE_VARS[rpath][name].first, default)
 end
 
 """

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -196,7 +196,7 @@ Return `default` (which is `nothing` if not specified) if the variable is not fo
 """
 function locvar(name::Union{Symbol,String}; default=nothing)
     name = String(name)
-    return ifelse(haskey(LOCAL_VARS, name), LOCAL_VARS[name].first, default)
+    return haskey(LOCAL_VARS, name) ? LOCAL_VARS[name].first : default
 end
 
 """

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -196,7 +196,7 @@ Return `default` (which is `nothing` if not specified) if the variable is not fo
 """
 function locvar(name::Union{Symbol,String}; default=nothing)
     name = String(name)
-    return haskey(LOCAL_VARS, name) ? LOCAL_VARS[name].first : default
+    return ifelse(haskey(LOCAL_VARS, name), LOCAL_VARS[name].first, default)
 end
 
 """

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -196,7 +196,7 @@ Return `default` (which is `nothing` if not specified) if the variable is not fo
 """
 function locvar(name::Union{Symbol,String}; default=nothing)
     name = String(name)
-    return ifelse(haskey(LOCAL_VARS, name), LOCAL_VARS[name].first, default)
+    return haskey(LOCAL_VARS, name) ? LOCAL_VARS[name].first : default
 end
 
 """
@@ -207,7 +207,7 @@ Return `default` (which is `nothing` if not specified) if the variable is not fo
 """
 function globvar(name::Union{Symbol,String}; default=nothing)
     name = String(name)
-    return get(GLOBAL_VARS, name, default)
+    return haskey(GLOBAL_VARS, name) ? GLOBAL_VARS[name].first : default
 end
 
 


### PR DESCRIPTION
Forgive the presumption of an unasked for PR, but it seemed easier to just start this and if you don't want it, no problem to close.

I am finding myself regularly using formulations like 

```
function default_pagevar(path, var, default)
    val = pagevar(path, var)
    return isnothing(val) ? default : val
end
```
and I thought it might be nice to have that as an option in `pagevar` itself (and possibly `locvar` too?). This just adds an optional third argument with `nothing` as the default. It shouldn't change any existing code, but is a nice little convenience.

I couldn't find an obvious place to put new tests, but let me know where you'd like them, and if any other functions could use the same option and I'll add them in.