### PR TITLE
More robust trim_stacktrace

### DIFF
--- a/src/eval/run.jl
+++ b/src/eval/run.jl
@@ -28,11 +28,17 @@ $SIGNATURES
 
 Returns only the stack traces which are related to the user's code.
 This means removing stack traces pointing to Franklin's code.
+Return the string as-is if the format is unrecognized.
 """
 function trim_stacktrace(s::String)
-    first_match_start = first(findfirst(STACKTRACE_TRIM_PAT, s))
-    # Keep only everything before the regex match.
-    return s[1:first_match_start-3]
+    try
+        first_match_start = first(findfirst(STACKTRACE_TRIM_PAT, s))
+        # Keep only everything before the regex match.
+        return s[1:first_match_start-3]
+    catch err
+        @debug "Unrecognized stack trace:\n$s" exception = (err, catch_backtrace())
+        return s
+    end
 end
 
 """

--- a/test/eval/run.jl
+++ b/test/eval/run.jl
@@ -106,3 +106,14 @@ end
         <p>B</p>
         """)
 end
+
+@testset "trim_stacktrace" begin
+    @test rstrip(F.trim_stacktrace("""
+        Stacktrace:
+            [1] f()
+            [2] top-level scope
+        """)) == """
+        Stacktrace:
+            [1] f()"""
+    @test F.trim_stacktrace("unrecognized pattern") == "unrecognized pattern"
+end


### PR DESCRIPTION
This PR makes `trim_stacktrace` more robust. I've been seeing build failure due to unguarded `first` in `first(findfirst(STACKTRACE_TRIM_PAT, s))`. Arguably, since the exact text representation of the stack trace is not part of the stable Julia API, it is ideal if `trim_stacktrace` can handle arbitrary string. Also, since `trim_stacktrace` is called at the error reporting portion of the code, I think it must not fail at all cost (c.f., `@error "hello" error("oops")` does not throw). This is why I am suggesting a catch-all patch. Of course, if this is not appropriate, I'm open to other implementation strategies (e.g., explicit `nothing` check before `first`).
