### PR TITLE
adding optional time taken per page

### DIFF
--- a/src/Franklin.jl
+++ b/src/Franklin.jl
@@ -84,6 +84,7 @@ const FD_ENV = LittleDict(
     :SILENT_MODE   => false,
     :QUIET_TEST    => false,
     :SHOW_WARNINGS => true,     # franklin-specific warnings
+    :SHOW_TIMINGS  => false,    # first pass, how much time spent on each pg
     :UTILS_COUNTER => 0,        # counter for utils module
     :UTILS_HASH    => nothing   # hash of the utils
     )

--- a/src/manager/file_utils.jl
+++ b/src/manager/file_utils.jl
@@ -101,7 +101,12 @@ function process_file(case::Symbol, fpair::Pair{String,String}, args...)::Int
     end
 
     try
-        process_file_err(case, fpair, args...)
+        δt = @elapsed process_file_err(case, fpair, args...)
+        if FD_ENV[:FULL_PASS] && FD_ENV[:SHOW_TIMINGS] && endswith(fpair.second, ".md")
+            println(
+                """[δt = $(round(δt, digits=2))s] $(fpair.second)"""
+            )
+        end
     catch err
         rp = fpair.first
         rp = rp[end-min(20, length(rp))+1 : end]

--- a/src/manager/franklin.jl
+++ b/src/manager/franklin.jl
@@ -61,6 +61,7 @@ function serve(; clear::Bool             = false,
                  log::Bool               = false,
                  host::String            = "127.0.0.1",
                  show_warnings::Bool     = true,
+                 show_timings::Bool      = false,
                  launch::Bool            = !single,
                  )::Union{Nothing,Int}
 
@@ -81,12 +82,13 @@ function serve(; clear::Bool             = false,
     isnothing(prepath) || set_var!(GLOBAL_VARS, "prepath", prepath.first)
 
     # Set context out of kwargs vars
-    FD_ENV[:CLEAR]      = clear
-    FD_ENV[:VERB]       = verb
-    FD_ENV[:FINAL_PASS] = is_final_pass
-    FD_ENV[:PRERENDER]  = prerender
+    FD_ENV[:CLEAR]             = clear
+    FD_ENV[:VERB]              = verb
+    FD_ENV[:FINAL_PASS]        = is_final_pass
+    FD_ENV[:PRERENDER]         = prerender
     FD_ENV[:NO_FAIL_PRERENDER] = no_fail_prerender
-    FD_ENV[:ON_WRITE]   = on_write
+    FD_ENV[:ON_WRITE]          = on_write
+    FD_ENV[:SHOW_TIMINGS]      = show_timings
 
     # check if there's a config file, if there is, check the variable
     # definitions looking at the ones that would affect overall structure etc.


### PR DESCRIPTION
The first pass can take some time depending on the complexity of individual pages and the hfuns used. This allows to pass a `show_timings=true` to `serve` to get a timing per page on the first full pass something like:

```
[δt = 0.11s] 09-ridge-cv-2.md
[δt = 0.85s] 09-convex-optimisation-3.md
```

