### PR TITLE
global anchors, reflink

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.10.43"
+version = "0.10.44"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/converter/latex/hyperrefs.jl
+++ b/src/converter/latex/hyperrefs.jl
@@ -72,13 +72,22 @@ lx_citep(lxc::LxCom, _) = form_href(lxc, "BIBR"; class="bibref")
 
 function lx_label(lxc::LxCom, _)
     refs = content(lxc.braces[1]) |> strip |> refstring
-    return "<a id=\"$refs\" class=\"anchor\"></a>"
+    # note: this overwrites a previous label if there was one already
+    GLOBAL_VARS["anchors"].first[refs] = url_curpage()
+    return "~~~<a id=\"$refs\" class=\"anchor\"></a>~~~"
+end
+
+@delay function lx_reflink(lxc::LxCom, _)
+    refs = content(lxc.braces[1]) |> strip |> refstring
+    anchors = globvar(:anchors)
+    refs in keys(anchors) || return "#"
+    return "$(anchors[refs])#$refs"
 end
 
 function lx_biblabel(lxc::LxCom, _)::String
     name = refstring(stent(lxc.braces[1]))
     PAGE_BIBREFS[name] = content(lxc.braces[2])
-    return "<a id=\"$name\" class=\"anchor\"></a>"
+    return "~~~<a id=\"$name\" class=\"anchor\"></a>~~~"
 end
 
 function lx_toc(::LxCom, _)

--- a/src/converter/latex/hyperrefs.jl
+++ b/src/converter/latex/hyperrefs.jl
@@ -74,7 +74,7 @@ function lx_label(lxc::LxCom, _)
     refs = content(lxc.braces[1]) |> strip |> refstring
     # note: this overwrites a previous label if there was one already
     GLOBAL_VARS["anchors"].first[refs] = url_curpage()
-    return "~~~<a id=\"$refs\" class=\"anchor\"></a>~~~"
+    return "<a id=\"$refs\" class=\"anchor\"></a>"
 end
 
 @delay function lx_reflink(lxc::LxCom, _)
@@ -87,7 +87,7 @@ end
 function lx_biblabel(lxc::LxCom, _)::String
     name = refstring(stent(lxc.braces[1]))
     PAGE_BIBREFS[name] = content(lxc.braces[2])
-    return "~~~<a id=\"$name\" class=\"anchor\"></a>~~~"
+    return "<a id=\"$name\" class=\"anchor\"></a>"
 end
 
 function lx_toc(::LxCom, _)

--- a/src/converter/latex/objects.jl
+++ b/src/converter/latex/objects.jl
@@ -15,6 +15,7 @@ const LX_INTERNAL_COMMANDS = [
     lxd("label",    1), # \label{id}
     lxd("biblabel", 2), # \biblabel{id}{name}
     lxd("toc",      0), # \toc
+    lxd("reflink",  1), # \reflink{id}
     # -------------------
     # inclusion / outputs (see converter/latex/io.jl)
     lxd("input",      2), # \input{what}{rpath}

--- a/src/converter/markdown/blocks.jl
+++ b/src/converter/markdown/blocks.jl
@@ -133,6 +133,8 @@ function convert_header(β::OCBlock, lxdefs::Vector{LxDef})::String
     else
         PAGE_HEADERS[rstitle] = (title, 1, parse(Int, hk[2]))
     end
+    # make the header anchor globally available
+    GLOBAL_VARS["anchors"].first[rstitle] = url_curpage()
     # return the title
     if globvar(:title_links)::Bool
         return html_hk(hk,

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -58,6 +58,8 @@ const GLOBAL_VARS_DEFAULT = [
     "fd_page_tags"     => Pair(nothing, (DTAG,  Nothing)),
     "fd_tag_pages"     => Pair(nothing, (DTAGI, Nothing)),
     "fd_rss_feed_url"  => dpair(""),
+    # keep track of all anchors {label => page} in case of clash, there's no guarantee
+    "anchors"          => dpair(LittleDict{String,String}()),
     # -----------------------------------------------------
     # LEGACY
     "div_content" => dpair(""), # see build_page


### PR DESCRIPTION
closes #854 (cc @jkrumbiegel)

Syntax:

```
[this is a link](\reflink{some id}) 
```

on another page either

```
## some id

or 

\label{some id}
```

(white spaces are allowed).

## Notes:

* if there's no header name clash or anchor name clash, this should just work
* if the same page has the same header multiple times, these get numbered and the number has to be referenced in the `some id` above
* if multiple pages have the same anchor, you get no guarantee of which link you'll get

Long story short, if you're using this, try not to have clashing references.