### PR TITLE
Add "code-output" class to code-output blocks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.10.45"
+version = "0.10.46"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/converter/latex/io.jl
+++ b/src/converter/latex/io.jl
@@ -103,7 +103,7 @@ function lx_output(lxc::LxCom, lxd::Vector{LxDef};
         end
     end
     # should it be reprocessed ?
-    reproc || return html_code(output)
+    reproc || return html_code(output; class="code-output")
     return reprocess(output, lxd)
 end
 

--- a/src/utils/html.jl
+++ b/src/utils/html.jl
@@ -58,17 +58,18 @@ Convenience function to introduce a code block. With indented blocks, the
 language will be resolved at build time; as a result no lines will be hidden
 for such blocks.
 """
-function html_code(c::AS, lang::AS="")::String
+function html_code(c::AS, lang::AS=""; class::String="")::String
     isempty(c) && return ""
+    class = ifelse(isempty(class), "", " $class")
     # if it's plaintext
-    isempty(lang) && return "<pre><code class=\"plaintext\">$c</code></pre>"
+    isempty(lang) && return "<pre><code class=\"plaintext$(class)\">$c</code></pre>"
     # escape it if it isn't already
     c = is_html_escaped(c) ? c : htmlesc(c)
     # remove hidden lines if any
     c = html_skip_hidden(c, lang)
     # if empty (e.g. via #hideall) return ""
     c == "" && return ""
-    return "<pre><code class=\"language-$lang\">$c</code></pre>"
+    return "<pre><code class=\"language-$(lang)$(class)\">$c</code></pre>"
 end
 
 """

--- a/test/converter/lx/input.jl
+++ b/test/converter/lx/input.jl
@@ -23,7 +23,7 @@ fs()
     h = F.convert_html(m)
 
     @test occursin("<p>Some string <pre><code class=\"language-julia\">$(F.htmlesc(read(joinpath(F.PATHS[:site], "assets", "index", "code", "s1.jl"), String)))</code></pre>", h)
-    @test occursin("Then maybe <pre><code class=\"plaintext\">$(F.htmlesc(read(joinpath(F.PATHS[:site], "assets", "index", "code",  "output", "s1.out"), String)))</code></pre>", h)
+    @test occursin("Then maybe <pre><code class=\"plaintext code-output\">$(F.htmlesc(read(joinpath(F.PATHS[:site], "assets", "index", "code",  "output", "s1.out"), String)))</code></pre>", h)
     @test occursin("Finally img: <img src=\"/assets/index/code/output/s1a.png\" alt=\"\"> done.", h)
 end
 

--- a/test/converter/md/md_defs2.jl
+++ b/test/converter/md/md_defs2.jl
@@ -12,7 +12,7 @@
         \\show{ex}
         """ |> fd2html
     @test occursin(
-        "<code class=\"plaintext\">5</code>", h)
+        "<code class=\"plaintext code-output\">5</code>", h)
     h = """
         @def x = Dict(
             :a => (1, 2, 3),
@@ -25,7 +25,7 @@
         \\show{ex}
         """ |> fd2html
     @test occursin(
-        "<code class=\"plaintext\">1</code>", h)
+        "<code class=\"plaintext code-output\">1</code>", h)
     h = """
         @def x = Dict(
             :a => (1,
@@ -40,7 +40,7 @@
         \\show{ex}
         """ |> fd2html
     @test occursin(
-        "<code class=\"plaintext\">2</code>", h)
+        "<code class=\"plaintext code-output\">2</code>", h)
 end
 
 # Blocks of definitions

--- a/test/eval/eval.jl
+++ b/test/eval/eval.jl
@@ -48,7 +48,7 @@ set_curpath("index.md")
                 <pre><code class="language-julia">$(F.htmlesc(raw"""a = 5
                 print(a^2)"""))</code></pre>
                 <p>then:</p>
-                <pre><code class="plaintext">25</code></pre>
+                <pre><code class="plaintext code-output">25</code></pre>
                 <p>done.</p>"""
 end
 
@@ -103,7 +103,7 @@ end
             <pre><code class="language-julia">$(F.htmlesc(raw"""a = 5
             print(a^2)"""))</code></pre>
             <p>then:</p>
-            <pre><code class="plaintext">25</code></pre>
+            <pre><code class="plaintext code-output">25</code></pre>
             <p>done.</p>"""
 
     # ------------
@@ -135,7 +135,7 @@ end
                 <pre><code class="language-julia">$(F.htmlesc(raw"""a = 5
                 print(a^2)"""))</code></pre>
                 <p>then:</p>
-                <pre><code class="plaintext">25</code></pre>
+                <pre><code class="plaintext code-output">25</code></pre>
                 <p>done.</p>"""
 end
 
@@ -160,7 +160,7 @@ end
                 a = [5, 2, 3, 4]
                 print(dot(a, a))"""))</code></pre>
                 <p>then:</p>
-                <pre><code class="plaintext">54</code></pre>
+                <pre><code class="plaintext code-output">54</code></pre>
                 <p>done.</p>"""
 end
 
@@ -210,7 +210,7 @@ end
                 <p>Simple code:</p>
                 <pre><code class="language-julia">$(F.htmlesc(raw"""sqrt(-1)"""))</code></pre>
                 <p>then:</p>
-                <pre><code class="plaintext">DomainError with -1.0:
+                <pre><code class="plaintext code-output">DomainError with -1.0:
                 sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
                 </code></pre>
                 <p>done.</p>"""
@@ -264,7 +264,7 @@ end
             println("Now: $a")
             rm(fn)"""))</code></pre>
             <p>done.</p>
-            <pre><code class="plaintext">Is this a file? true
+            <pre><code class="plaintext code-output">Is this a file? true
             Now: 2
             </code></pre>
             """
@@ -285,7 +285,7 @@ end
     @test h // """
                 <pre><code class="language-julia">$(F.htmlesc(raw"""a = 5
                 a *= 2"""))</code></pre>
-                <pre><code class="plaintext">10</code></pre>"""
+                <pre><code class="plaintext code-output">10</code></pre>"""
 
     # Show with stdout
     h = raw"""
@@ -303,7 +303,7 @@ end
                 <pre><code class="language-julia">$(F.htmlesc(raw"""a = 5
                 println("hello")
                 a *= 2"""))</code></pre>
-                <pre><code class="plaintext">hello
+                <pre><code class="plaintext code-output">hello
                 10</code></pre>"""
 
     # issue 427
@@ -322,5 +322,5 @@ end
             <pre><code class="language-julia">$(F.htmlesc(raw"""a = 5
             a *= 2
             # hello"""))</code></pre>
-            <pre><code class="plaintext">10</code></pre>"""
+            <pre><code class="plaintext code-output">10</code></pre>"""
 end

--- a/test/eval/extras.jl
+++ b/test/eval/extras.jl
@@ -62,7 +62,7 @@ end
         df = DataFrame(A = 1:4, B = ["M", "F", "F", "M"])
         first(df, 3)
         """))</code></pre>
-        <pre><code class="plaintext">
+        <pre><code class="plaintext code-output">
         3×2 DataFrame
          Row │ A      B
              │ Int64  String

--- a/test/eval/integration.jl
+++ b/test/eval/integration.jl
@@ -10,7 +10,7 @@
         \output{ex}
         """ |> fd2html_td
     @test isapproxstr(s, """
-         <pre><code class="plaintext">12</code></pre>
+         <pre><code class="plaintext code-output">12</code></pre>
         """)
 end
 
@@ -32,12 +32,12 @@ end
             <pre><code class="language-julia">
             x &#61; 1
             </code></pre>
-            <pre><code class="plaintext">1</code></pre>
+            <pre><code class="plaintext code-output">1</code></pre>
 
             <p>B</p>
 
             <pre><code class="language-julia">print&#40;x&#41;</code></pre>
-            <pre><code class="plaintext">1</code></pre>
+            <pre><code class="plaintext code-output">1</code></pre>
             """)
 end
 
@@ -57,10 +57,10 @@ end
     @test isapproxstr(a, """
         <p>A</p>
         <pre><code class="language-julia">x &#61; :ab</code></pre>
-        <pre><code class="plaintext">:ab</code></pre>
+        <pre><code class="plaintext code-output">:ab</code></pre>
         <p>B</p>
         <pre><code class="language-julia">x &#61; :&#40;a&#43;b&#41;</code></pre>
-        <pre><code class="plaintext">:(a + b)</code></pre>
+        <pre><code class="plaintext code-output">:(a + b)</code></pre>
         <p>C</p>
         """)
 end

--- a/test/eval/run.jl
+++ b/test/eval/run.jl
@@ -87,7 +87,7 @@ end
        B""" |> fd2html_td
     @test isapproxstr(s, """
         <p>A</p>
-        <pre><code class="plaintext">1</code></pre>
+        <pre><code class="plaintext code-output">1</code></pre>
         <p>B</p>
         """)
     s = raw"""
@@ -100,7 +100,7 @@ end
        B""" |> fd2html_td
     @test isapproxstr(s, """
         <p>A</p>
-        <pre><code class="plaintext">"hello"</code></pre>
+        <pre><code class="plaintext code-output">"hello"</code></pre>
         <p>B</p>
         """)
 end

--- a/test/global/eval.jl
+++ b/test/global/eval.jl
@@ -24,7 +24,7 @@
     h = foo |> fd2html_td
 
     @test isapproxstr(h, """
-                <pre><code class="language-julia">$(F.htmlesc("""println(randn())"""))</code></pre> <pre><code class=\"plaintext\">$a</code></pre>
+                <pre><code class="language-julia">$(F.htmlesc("""println(randn())"""))</code></pre> <pre><code class=\"plaintext code-output\">$a</code></pre>
                 """)
 
     # XXX TEXT MODIFICATION + IN SCOPE --> NO REEVAL
@@ -34,7 +34,7 @@
     h = foo |> fd2html_td
 
     @test isapproxstr(h, """
-                <pre><code class="language-julia">$(F.htmlesc("""println(randn())"""))</code></pre> <p><pre><code class=\"plaintext\">$a</code></pre> etc</p>
+                <pre><code class="language-julia">$(F.htmlesc("""println(randn())"""))</code></pre> <p><pre><code class=\"plaintext code-output\">$a</code></pre> etc</p>
                 """)
 
     # XXX CODE ADDITION --> NO REEVAL OF FIRST BLOCK
@@ -58,18 +58,18 @@
             println(randn())
             """))
         </code></pre>
-        <p><pre><code class=\"plaintext\">$a</code></pre> etc</p>
+        <p><pre><code class=\"plaintext code-output\">$a</code></pre> etc</p>
         <pre><code class="language-julia">
             $(F.htmlesc(raw"""
             println(randn())
             """))
         </code></pre>
-        <pre><code class=\"plaintext\">$b</code></pre>
+        <pre><code class=\"plaintext code-output\">$b</code></pre>
         <pre><code class="language-julia">
             $(F.htmlesc(raw"""
             println(randn())"""))
         </code></pre>
-        <pre><code class=\"plaintext\">$c</code></pre>
+        <pre><code class=\"plaintext code-output\">$c</code></pre>
         """)
 
     # XXX CODE MODIFICATION --> REEVAL OF BLOCK AND AFTER
@@ -98,18 +98,18 @@
             println(randn())
             """))
         </code></pre>
-        <pre><code class=\"plaintext\">$a</code></pre>
+        <pre><code class=\"plaintext code-output\">$a</code></pre>
         <pre><code class="language-julia">$(F.htmlesc(raw"""
             # modif
             println(randn())
             """))
         </code></pre>
-        <pre><code class=\"plaintext\">$d</code></pre>
+        <pre><code class=\"plaintext code-output\">$d</code></pre>
         <pre><code class="language-julia">$(F.htmlesc(raw"""
             println(randn())
             """))
         </code></pre>
-        <pre><code class=\"plaintext\">$e</code></pre>
+        <pre><code class=\"plaintext code-output\">$e</code></pre>
         """)
 end
 
@@ -137,13 +137,13 @@ end
                 println(a)
                 """))
             </code></pre>
-            <pre><code class=\"plaintext\">5</code></pre>
+            <pre><code class=\"plaintext code-output\">5</code></pre>
             <pre><code class="language-julia">$(F.htmlesc(raw"""
                 a += 3
                 println(a)
                 """))
             </code></pre>
-            <pre><code class=\"plaintext\">8</code></pre>
+            <pre><code class=\"plaintext code-output\">8</code></pre>
             """)
 
     h = raw"""
@@ -172,19 +172,19 @@ end
                 println(a)
                 """))
             </code></pre>
-            <pre><code class=\"plaintext\">5</code></pre>
+            <pre><code class=\"plaintext code-output\">5</code></pre>
             <pre><code class="language-julia">$(F.htmlesc(raw"""
                 a += 1
                 println(a)
                 """))
             </code></pre>
-            <pre><code class=\"plaintext\">6</code></pre>
+            <pre><code class=\"plaintext code-output\">6</code></pre>
             <pre><code class="language-julia">$(F.htmlesc(raw"""
                 a += 3
                 println(a)
                 """))
             </code></pre>
-            <pre><code class=\"plaintext\">9</code></pre>
+            <pre><code class=\"plaintext code-output\">9</code></pre>
             """)
 end
 
@@ -197,7 +197,7 @@ end
        """ |> F.fd2html
     @test isapproxstr(s, """
         <pre><code class="language-julia">x&#61;5 # a</code></pre>
-        <pre><code class="plaintext">5</code></pre>
+        <pre><code class="plaintext code-output">5</code></pre>
         """)
     s = """
        ```!

--- a/test/integration/literate.jl
+++ b/test/integration/literate.jl
@@ -98,12 +98,12 @@ end
             y = 2//5
             """))
         </code></pre>
-        <pre><code class="plaintext">2//5</code></pre>
+        <pre><code class="plaintext code-output">2//5</code></pre>
         <p>When adding <code>x</code> and <code>y</code> together we obtain a new rational number:</p>
         <pre><code class="language-julia">$(F.htmlesc(raw"""
             z = x + y
             """))
-        </code></pre><pre><code class="plaintext">11//15</code></pre>
+        </code></pre><pre><code class="plaintext code-output">11//15</code></pre>
         """)
 
     # issue 592
@@ -143,7 +143,7 @@ end
     @test h // """
         <h1 id="rational_numbers"><a href="#rational_numbers" class="header-anchor">Rational numbers</a></h1>
         <pre><code class="language-julia">$(F.htmlesc(raw"""const a = 1"""))</code></pre>
-        <pre><code class="language-julia">$(F.htmlesc(raw"""a = 5"""))</code></pre><pre><code class="plaintext">5</code></pre>
+        <pre><code class="language-julia">$(F.htmlesc(raw"""a = 5"""))</code></pre><pre><code class="plaintext code-output">5</code></pre>
         """
 end
 

--- a/test/integration/literate_extras.jl
+++ b/test/integration/literate_extras.jl
@@ -30,11 +30,11 @@ fs()
     @test isapproxstr(h, """
         <p>INI</p>
         <p>A</p>
-        <pre><code class="language-julia">$(F.htmlesc(raw"""1 + 1"""))</code></pre><pre><code class="plaintext">2</code></pre>
+        <pre><code class="language-julia">$(F.htmlesc(raw"""1 + 1"""))</code></pre><pre><code class="plaintext code-output">2</code></pre>
         <p>B</p>
         <pre><code class="language-julia">$(F.htmlesc(raw"""2^2;"""))</code></pre>
         <p>C</p>
-        <pre><code class="language-julia">$(F.htmlesc(raw"""println("hello")"""))</code></pre><pre><code class="plaintext">hello
+        <pre><code class="language-julia">$(F.htmlesc(raw"""println("hello")"""))</code></pre><pre><code class="plaintext code-output">hello
         </code></pre>
         <p>done.</p>
         """)


### PR DESCRIPTION
Now:

````
julia> s = """
       ```!
       1+1
       ```
       """ |> fd2html |> println
<pre><code class="language-julia">1&#43;1</code></pre>
<pre><code class="plaintext code-output">2</code></pre>
````

so same as before but there's the extra class `code-output` that allows separate styling of code output blocks. 

closes #856 

