### PR TITLE
Add note for custom domain of project gh-page

### DIFF
--- a/docs/workflow/deploy.md
+++ b/docs/workflow/deploy.md
@@ -28,7 +28,9 @@ Start by creating an empty GitHub repository
 \warn{
   When you consider a _project website_, you **must** define a `prepath` variable in your `config.md` with the name of that project. For instance: `@def prepath = "myWebsite"`.
   This is used upon deployment to indicate that the base URL of your website is `username.github.io/myWebsite/` instead of `username.github.io`.
-  If you forget to do that, among other problems the CSS won't load and your website will look terrible 😅.
+  If you forget to do that, among other problems the CSS won't load and your website will look terrible 😅. 
+  
+  However, if you add a custom domain like `example.com` to your *project* repo like `myWebsite`, then the variable `prepath` should be set empty string to make the CSS work.
 }
 
 @@tlist


### PR DESCRIPTION
After adding a custom domain `stdsem.me` to my **project** gh-page [zfengg/StdSem](https://github.com/zfengg/StdSem), I found the CSS didn't work in the first place and it looks terrible.

However, by setting the important global variable `@def prepath="" `, i.e., the empty string, the website [stdsem.me](https://stdsem.me) looks fine again. Hence I think this may be helpful for others who met the same problem.

Really appreciate `Franklin.jl` :+1: .