### PR TITLE
Add the `fail_on_warning` keyword

### DIFF
--- a/src/Franklin.jl
+++ b/src/Franklin.jl
@@ -68,24 +68,25 @@ const BIG_INT = typemax(Int)
 # but works fine for what we do here and limits the necessity of passing lots
 # of arguments to lots of functions.
 const FD_ENV = LittleDict(
-    :FULL_PASS     => true,
-    :CLEAR         => false,
-    :VERB          => false,
-    :FINAL_PASS    => false,
-    :PRERENDER     => false,
-    :NO_FAIL_PRERENDER => true,  # skip prerendering if fails on a page
-    :ON_WRITE      => (_, _) -> nothing,
-    :FORCE_REEVAL  => false,
-    :CUR_PATH      => "",        # complements fd-rpath
-    :SOURCE        => "",        # keeps track of the origin of a HTML string
-    :OFFSET_LXDEFS => -BIG_INT,  # helps keep track of order in lxcoms/envs
-    :DEBUG_MODE    => false,
-    :SUPPRESS_ERR  => false,
-    :SILENT_MODE   => false,
-    :QUIET_TEST    => false,
-    :SHOW_WARNINGS => true,     # franklin-specific warnings
-    :UTILS_COUNTER => 0,        # counter for utils module
-    :UTILS_HASH    => nothing   # hash of the utils
+    :FULL_PASS         => true,
+    :CLEAR             => false,
+    :VERB              => false,
+    :FINAL_PASS        => false,
+    :PRERENDER         => false,
+    :NO_FAIL_PRERENDER => true,     # skip prerendering if fails on a page
+    :ON_WRITE          => (_, _) -> nothing,
+    :FORCE_REEVAL      => false,
+    :CUR_PATH          => "",       # complements fd-rpath
+    :SOURCE            => "",       # keeps track of the origin of a HTML string
+    :OFFSET_LXDEFS     => -BIG_INT, # helps keep track of order in lxcoms/envs
+    :DEBUG_MODE        => false,
+    :SUPPRESS_ERR      => false,
+    :SILENT_MODE       => false,
+    :QUIET_TEST        => false,
+    :SHOW_WARNINGS     => true,     # franklin-specific warnings
+    :FAIL_ON_WARNING   => false,    # turn warnings into fatal errors
+    :UTILS_COUNTER     => 0,        # counter for utils module
+    :UTILS_HASH        => nothing   # hash of the utils
     )
 
 utils_name()   = "Utils_$(FD_ENV[:UTILS_COUNTER]::Int)"

--- a/src/manager/franklin.jl
+++ b/src/manager/franklin.jl
@@ -44,6 +44,7 @@ Keyword arguments:
                       variables
 * `host="127.0.0.1"`: the host to use for the local server
 * `show_warnings=true`: whether to show franklin  warnings
+* `fail_on_warning=false`: if true, warnings become fatal errors
 * `launch=!single`:   whether to launch the browser when serving
 """
 function serve(; clear::Bool             = false,
@@ -61,6 +62,7 @@ function serve(; clear::Bool             = false,
                  log::Bool               = false,
                  host::String            = "127.0.0.1",
                  show_warnings::Bool     = true,
+                 fail_on_warning::Bool   = false,
                  launch::Bool            = !single,
                  )::Union{Nothing,Int}
 
@@ -73,6 +75,8 @@ function serve(; clear::Bool             = false,
     if silent || !show_warnings
         FD_ENV[:SHOW_WARNINGS] = false
     end
+
+    FD_ENV[:FAIL_ON_WARNING] = fail_on_warning
 
     # in case of optim, there may be a prepath given which should be
     # kept

--- a/src/manager/post_processing.jl
+++ b/src/manager/post_processing.jl
@@ -18,6 +18,7 @@ Does a full pass followed by a pre-rendering and minification step.
 * `no_fail_prerender=true`: whether to ignore errors during the pre-rendering
                              process
 * `suppress_errors=true`:   whether to suppress errors
+* `fail_on_warning=false`:   if true, warnings become fatal errors
 * `cleanup=true`:   whether to empty environment dictionaries
 * `on_write(pg, fd_vars)`: callback function after the page is rendered,
                       passing as arguments the rendered page and the page
@@ -29,8 +30,10 @@ pages).
 """
 function optimize(; prerender::Bool=true, minify::Bool=true, sig::Bool=false,
                     prepath::String="", no_fail_prerender::Bool=true, on_write::Function=(_,_)->nothing,
-                    suppress_errors::Bool=true, clear::Bool=false, cleanup::Bool=true)::Union{Nothing,Bool}
+                    suppress_errors::Bool=true, clear::Bool=false, cleanup::Bool=true,
+                    fail_on_warning::Bool = false)::Union{Nothing,Bool}
     suppress_errors && (FD_ENV[:SUPPRESS_ERR] = true)
+    FD_ENV[:FAIL_ON_WARNING] = fail_on_warning
     #
     # Prerendering
     #

--- a/src/utils/warnings.jl
+++ b/src/utils/warnings.jl
@@ -56,5 +56,6 @@ function print_warning(msg)
         println(line)
     end
     printyb("└\n")
+    FD_ENV[:FAIL_ON_WARNING] && throw(ErrorException("`fail_on_warning` is true, so exiting with error"))
     return
 end


### PR DESCRIPTION
A very naive attempt at fixing #785.

This PR adds the `fail_on_warning::Bool` keyword to the following functions:
1. `serve`
2. `optimize`

This keyword is optional. If not specified, the default value is `fail_on_warning = false`.

If `fail_on_warning` is `true`, then if a "Franklin Warning" is printed, a fatal error is thrown.