### PR TITLE
adding support for mdstring in Literate

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.10.51"
+version = "0.10.52"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/eval/literate.jl
+++ b/src/eval/literate.jl
@@ -40,13 +40,23 @@ function literate_to_franklin(rpath::AS)::Tuple{String,Bool}
     # don't show Literate's infos
     Logging.disable_logging(Logging.LogLevel(Logging.Info))
     # >> output the markdown
-    Literate.markdown(fpath, outpath;
-                      config=Dict("codefence" => (LITERATE_JULIA_FENCE => "```")),
-                      documenter=false, postprocess=literate_post_process, credit=false)
+    Literate.markdown(
+        fpath, outpath;
+        flavor=Literate.CommonMarkFlavor(),
+        mdstrings=locvar(:literate_mds)::Bool,
+        config=Dict("codefence" => (LITERATE_JULIA_FENCE => "```")),
+        postprocess=literate_post_process,
+        credit=false
+    )
     # >> output the script
-    Literate.script(fpath, outpath; documenter=false,
-                      postprocess=s->(MESSAGE_FILE_GEN_LIT * s),
-                      name=fname * "_script", credit=false)
+    Literate.script(
+        fpath, outpath;
+        flavor=Literate.CommonMarkFlavor(),
+        mdstrings=locvar(:literate_mds)::Bool,
+        postprocess=s->(MESSAGE_FILE_GEN_LIT * s),
+        name=fname * "_script",
+        credit=false
+    )
     # bring back logging
     Logging.disable_logging(Logging.LogLevel(Logging.Debug))
     # see if things have changed

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -60,6 +60,8 @@ const GLOBAL_VARS_DEFAULT = [
     "fd_rss_feed_url"  => dpair(""),
     # keep track of all anchors {label => page} in case of clash, there's no guarantee
     "anchors"          => dpair(LittleDict{String,String}()),
+    # allow md strings in Literate
+    "literate_mds"     => dpair(false),
     # -----------------------------------------------------
     # LEGACY
     "div_content" => dpair(""), # see build_page


### PR DESCRIPTION
closes #880 

@luraess could you kindly test this? (check out this branch of the project + `dev` it)

Here's what I used on my side:

### literate.md file

```
+++
literate_mds = true
+++

# Franklin + Literate

\literate{/_literate/ex1.jl}
```

### literate/ex1.jl file

```julia
# ## Literate example

1 + 1

md"""
foo **bar** _baz_ $x = 3$
"""
```

### result

<img width="763" alt="Screenshot 2021-09-10 at 16 10 24" src="https://user-images.githubusercontent.com/10897531/132866890-8dbbe382-4a0b-4db5-b614-b864de940360.png">


### Notes

I tried this with `@@` etc, works fine e.g.:

```
# ## Literate example

1 + 1

md"""
~~~
<style>
.test { color: red; }
</style>
~~~

foo **bar** _baz_ $x = 3$ @@test foo @@
"""
```