### PR TITLE
I885

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.10.54"
+version = "0.10.55"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/converter/html/blocks.jl
+++ b/src/converter/html/blocks.jl
@@ -68,7 +68,7 @@ function process_html_cond(hs::AS, qblocks::Vector{AbstractBlock},
                 k ⊻= βi isa HIsNotDef
             elseif βi isa Union{HIsEmpty, HIsNotEmpty}
                 v = locvar(βi.vname)
-                e = _isempty(v)
+                e = _isemptyvar(v)
                 k = ifelse(βi isa HIsEmpty, e, !e)
             end
         else
@@ -155,9 +155,9 @@ function process_html_cond(hs::AS, qblocks::Vector{AbstractBlock},
 end
 
 # used for the HIsEmpty, HIsNotEmpty
-_isempty(v::T) where T = hasmethod(isempty, (T,)) ? isempty(v) : false
-_isempty(::Nothing)    = true
-_isempty(v::Date)      = (v == Date(1,1,1))
+_isemptyvar(v::T) where T = hasmethod(isempty, (T,)) ? isempty(v) : false
+_isemptyvar(::Nothing)    = true
+_isemptyvar(v::Date)      = (v == Date(1,1,1))
 
 
 """

--- a/src/eval/run.jl
+++ b/src/eval/run.jl
@@ -67,12 +67,19 @@ function run_code(mod::Module, code::AS, out_path::AS;
     isempty(code) && return nothing
     strip_code && (code = strip(code))
     exs  = parse_code(strip(code))
-    isempty(exs) && return nothing
     ne   = length(exs)
     res  = nothing # to capture final result
     err  = nothing
     stacktrace = nothing
     ispath(out_path) || mkpath(dirname(out_path))
+
+    # we do this here so that `out_path` is still generated to avoid
+    # issue #885
+    if isempty(exs)
+        write(out_path, "")
+        return nothing
+    end
+
     open(out_path, "w") do outf
         if !FD_ENV[:SILENT_MODE]::Bool
             rprint("→ evaluating code [$(out_path |> basename |> splitext |> first)] in ($(locvar("fd_rpath")))")

--- a/src/eval/run.jl
+++ b/src/eval/run.jl
@@ -67,6 +67,7 @@ function run_code(mod::Module, code::AS, out_path::AS;
     isempty(code) && return nothing
     strip_code && (code = strip(code))
     exs  = parse_code(strip(code))
+    isempty(exs) && return nothing
     ne   = length(exs)
     res  = nothing # to capture final result
     err  = nothing

--- a/test/eval/run.jl
+++ b/test/eval/run.jl
@@ -46,7 +46,7 @@ end
         Random.seed!(555)
         println("hello")
         b = randn()
-        b > 0
+        iszero(b)
         """
     r = F.run_code(mod1, c, junk)
 


### PR DESCRIPTION
closes: #885

There was an issue when evaluating literate files with no code (or code cells that were effectively empty or just comments)

1. the expressions for that code block would be empty, this had to be taken into account to avoid a 0-index error
2. we still need to write an output file so that in the `showall` mode of Literate there would be nothing shown as opposed to an error saying that some file doesn't exist.

Here's the result now with the file mentioned in #885 

<img width="749" alt="Screenshot 2021-09-19 at 12 41 29" src="https://user-images.githubusercontent.com/10897531/133924617-888aa520-f419-4b7b-8707-0c186ca55fa8.png">

