### PR TITLE
Avoid pagevar cycle leading to stack overflow (#891)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.10.58"
+version = "0.10.59"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Franklin.jl
+++ b/src/Franklin.jl
@@ -94,6 +94,9 @@ utils_symb()   = Symbol(utils_name())
 utils_module() = getproperty(Main, utils_symb())
 utils_hash()   = nothing
 
+# HACK avoid stackoverflow for pagevar cycle (see juliacomputing issue #891)
+const PAGEVAR_DEPTH = Ref{Int}(0)
+
 # keep track of pages which need to be re-evaluated after the full-pass
 # to ensure that their h-fun are working with the fully-defined scope
 # (e.g. if need list of all tags)

--- a/src/converter/markdown/md.jl
+++ b/src/converter/markdown/md.jl
@@ -33,6 +33,13 @@ function convert_md(
     # instantiate page dictionaries
     isrecursive || isinternal || set_page_env()
 
+    # HACK avoid stackoverflow in pagevar loop see #891
+    if pagevar
+        PAGEVAR_DEPTH[] += 1
+    else
+        PAGEVAR_DEPTH[] = 0
+    end
+
     #
     # Parsing of the markdown string
     # (to find latex command, latex definitions, math envs etc.)

--- a/src/converter/markdown/tags.jl
+++ b/src/converter/markdown/tags.jl
@@ -11,6 +11,7 @@ Note: the `clean_tags` cleans up orphan tags (tags that wouldn't be pointing
 to any page anymore).
 """
 function generate_tag_pages(refresh_tags=Set{String}())::Nothing
+    globvar(:generate_tags)::Bool || return
     # if there are no page tags, cleanup and finish
     PAGE_TAGS = globvar("fd_page_tags")
     isnothing(PAGE_TAGS) && return clean_tags()

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -64,6 +64,8 @@ const GLOBAL_VARS_DEFAULT = [
     "literate_mds"     => dpair(false),
     # each cell runs a cd in/out OUT_PATH
     "auto_code_path"   => dpair(false),
+    # don't generate tag pages
+    "generate_tags"    => dpair(true),
     # -----------------------------------------------------
     # LEGACY
     "div_content" => dpair(""), # see build_page
@@ -239,6 +241,9 @@ processed yet so force a pass over that page.
 Return `default` (which is `nothing` if not specified) if the variable is not found.
 """
 function pagevar(rpath::AS, name::Union{Symbol,String}; default=nothing)
+    # HACK avoid stackoverflow for pagevar cycle
+    PAGEVAR_DEPTH[] > 5 && return default
+
     # only split extension if it's .md or .html (otherwise can cause trouble
     # if there's a dot in the page name... not recommended but happens.)
     rpc = splitext(rpath)


### PR DESCRIPTION
* add a depth indicator for `pagevar`, stop the cycle if we go deeper than 5
* add a `generate_tags` which can be set to false for sites that have been migrated and might still have some `tags = ...` but actually don't use them
* patch release