### PR TITLE
Remove unsupported `force` kwarg from `FD_CAN_PRERENDER`

### DIFF
--- a/src/manager/post_processing.jl
+++ b/src/manager/post_processing.jl
@@ -57,7 +57,7 @@ function optimize(;
     #
     # Prerendering
     #
-    if prerender && !FD_CAN_PRERENDER(; force=true)
+    if prerender && !FD_CAN_PRERENDER()
         prerender = false
     end
     prerender && !FD_CAN_HIGHLIGHT(; force=true)


### PR DESCRIPTION
The `force` kwarg is not present in the `FD_CAN_PRERENDER` definition and causes the build to fail when deploying a site.