### PR TITLE
Allow classes like a:b/c with @@

### DIFF
--- a/src/parser/tokens.jl
+++ b/src/parser/tokens.jl
@@ -253,7 +253,7 @@ In combination with `incrlook`, checks to see if we have something that looks
 like a @@div describing the opening of a div block. Triggering char is a first
 `@`.
 """
-is_div_open(i::Int, c::Char) = (i == 1 && return c == '@'; return α(c, ('-','_', ',', NUM_CHAR...)))
+is_div_open(i::Int, c::Char) = (i == 1 && return c == '@'; return α(c, ('-','_', ',', ':', '/', NUM_CHAR...)))
 
 """
 $(SIGNATURES)

--- a/test/parser/1-tokenize.jl
+++ b/test/parser/1-tokenize.jl
@@ -118,7 +118,7 @@ end
         B3
     C
     @@da
-        @@db
+        @@db,dc:dd/de
             E
         @@
     @@
@@ -135,7 +135,7 @@ end
     @test islr(t[6])
     @test istok(t[7], :DIV_OPEN, "@@da")
     @test isind(t[8]) && t[8].lno == 8
-    @test istok(t[9], :DIV_OPEN, "@@db")
+    @test istok(t[9], :DIV_OPEN, "@@db,dc:dd/de")
     @test isind(t[10]) && t[10].lno == 9  # in front of E
     @test isind(t[11]) && t[11].lno == 10 # in front of @@
     @test istok(t[12], :DIV_CLOSE, "@@")


### PR DESCRIPTION
Tailwind CSS (https://tailwindcss.com/) is a perfect match for `@@` but it has a many class names like `hover:basis-1/2` that the parser failed to reconize due to pre-matured end-of-token.
This PR fixes this issue.