### PR TITLE
fix clipboard script for highlight.js pre-render

### DIFF
--- a/demos/_layout/foot_clipboard.html
+++ b/demos/_layout/foot_clipboard.html
@@ -10,12 +10,12 @@
 	var pre = document.getElementsByTagName('pre');
 
 	// Add a copy button in the 'pre' element.
-	// which only has the className of 'language-'.
+	// which only has the className of 'language-' or ' hljs'(if enable highlight.js pre-render).
 
 	for (var i = 0; i < pre.length; i++) {
-		var isLanguage = pre[i].children[0].className.indexOf('language-');
-
-		if ( isLanguage === 0 ) {
+		var tag_name = pre[i].children[0].className
+            	var isLanguage = tag_name.startsWith('language-') || tag_name.endsWith(' hljs');
+		if ( isLanguage ) {
 			var button           = document.createElement('button');
 					button.className = 'copy-button';
 					button.textContent = 'Copy';


### PR DESCRIPTION
```julia
using NodeJS; run(`$(npm_cmd()) install highlight.js`);
using Franklin; Franklin.optimize()
```

I'm not sure if this is the right fix (almost zero web-dev knowledges). But it works locally.