### PR TITLE
remove unbound type parameter

### DIFF
--- a/src/converter/latex/latex.jl
+++ b/src/converter/latex/latex.jl
@@ -74,7 +74,7 @@ $SIGNATURES
 
 Convenience function to take a markdown string (e.g. produced by a latex command) and re-parse it.
 """
-function reprocess(s::AS, lxdefs::Vector{<:LxDef}; nostripp=false) where T
+function reprocess(s::AS, lxdefs::Vector{<:LxDef}; nostripp=false)
     r = convert_md(s, lxdefs;
                    isrecursive=true, isconfig=false, has_mddefs=false,
                    nostripp=nostripp)


### PR DESCRIPTION
Unbound type parameters often cause performance issues and run time dispatch.

Issue found using https://github.com/JuliaLang/julia/pull/46608