### PR TITLE
add ttl argument to check_ping

### DIFF
--- a/src/manager/post_processing.jl
+++ b/src/manager/post_processing.jl
@@ -320,7 +320,8 @@ $SIGNATURES
 
 Verify all links in generated HTML.
 """
-function verify_links()::Nothing
+function verify_links(; ttl=64)::Nothing
+    @assert 1 ≤ ttl ≤ 255 "IP Time to Live must be between 1 and 255"
     # if this is done before `serve` is called
     if isempty(PATHS)
         FOLDER_PATH[] = pwd()
@@ -328,7 +329,7 @@ function verify_links()::Nothing
     end
     # check that the user is online (otherwise only verify internal links)
     # this is fast as it uses `ping` and does not resolve a request
-    online = findfirst(check_ping, first.(IP_CHECK)) !== nothing
+    online = findfirst(ipadd -> check_ping(ipadd, ttl), first.(IP_CHECK)) !== nothing
 
     print("Verifying links...")
     if online

--- a/src/utils/misc.jl
+++ b/src/utils/misc.jl
@@ -223,14 +223,15 @@ function rprint(s::AS)::Nothing
 end
 
 """
-    check_ping(ipaddr)
+    check_ping(ipaddr, ttl)
 
-Try a single ping to an address `ipaddr`. There's a timeout of 1s.
+Try a single ping to an address `ipaddr`. `ttl` limits the maximum number of IP
+routers that the packet can go through before being thrown away.
 """
-function check_ping(ipaddr)
+function check_ping(ipaddr, ttl)
     # portable count (creds https://docdave.science/writing-ping-in-julia/)
     opt = ifelse(Sys.iswindows(), "-n", "-c")
-    return success(`ping $opt 1 -t 1 $ipaddr`)
+    return success(`ping $opt 1 -t $ttl $ipaddr`)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -144,7 +144,7 @@ println("😅 😅 😅 😅")
 # check quickly if the IPs in IP_CHECK are still ok
 println("Verifying ip addresses, if online these should succeed.")
 for (addr, name) in F.IP_CHECK
-    println(rpad("Ping $name:", 13), ifelse(F.check_ping(addr), "✓", "✗"), ".")
+    println(rpad("Ping $name:", 13), ifelse(F.check_ping(addr, 64), "✓", "✗"), ".")
 end
 
 


### PR DESCRIPTION
Fixes #1004

To have the exact same behavior as before one can simply run
```julia
verify_links(; ttl=1)
```