### PR TITLE
Add demo to render Dataframe as HTML table

### DIFF
--- a/demos/Project.toml
+++ b/demos/Project.toml
@@ -1,9 +1,11 @@
 [deps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 JSServe = "824d6782-a2ef-11e9-3a09-e5662e0c26f9"
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 TikzCDs = "1e332c56-9431-4126-8a34-92cbdf251ae4"
 WGLMakie = "276b4fcb-3e11-5398-bf8b-a0c2d153d008"

--- a/demos/index.md
+++ b/demos/index.md
@@ -38,6 +38,7 @@ will be rendered as:
 
 {{ render_table }}
 
+This done via a `hfun_render_table` which can be found in [`utils.jl`](https://github.com/tlienart/Franklin.jl/blob/master/demos/utils.jl).
 
 ## (018) collapsible block
 How to make a section expand when clicked, so that content is initially hidden? (Based on [this html guide](https://www.w3schools.com/howto/howto_js_collapsible.asp).)

--- a/demos/index.md
+++ b/demos/index.md
@@ -20,6 +20,25 @@ The ordering is reverse chronological but just use the table of contents to guid
 
 \toc
 
+## (019) From `Dataframe` to HTML table
+
+If you have some data that you would like to manipulate and render nicely in `Franklin`, you can use the following snippet relying on [`DataFrames.jl`](https://github.com/JuliaData/DataFrames.jl)
+and [`PrettyTables.jl`](https://github.com/ronisbr/PrettyTables.jl).
+
+The following `Dataframe`: 
+
+```julia
+A = rand('A':'Z', 10)
+B = rand(1:10, 10)
+C = rand(Bool, 10)
+DataFrame(; A, B, C)
+```
+
+will be rendered as:
+
+{{ render_table }}
+
+
 ## (018) collapsible block
 How to make a section expand when clicked, so that content is initially hidden? (Based on [this html guide](https://www.w3schools.com/howto/howto_js_collapsible.asp).)
 

--- a/demos/utils.jl
+++ b/demos/utils.jl
@@ -7,6 +7,8 @@ using DelimitedFiles
 using TikzCDs
 using Dates
 using Weave
+using DataFrames
+using PrettyTables
 
 # ========================================================================
 

--- a/demos/utils.jl
+++ b/demos/utils.jl
@@ -116,3 +116,22 @@ function hfun_insert_weave(params)
     html = html[range]
     return html
 end
+###########
+### 019 ###
+###########
+    
+function hfun_render_table()
+    A = rand('A':'Z', 10)
+    B = rand(1:10, 10)
+    C = rand(Bool, 10)
+    df = DataFrame(; A, B, C)    
+    pretty_table(
+        String, # export table as a String
+        df;
+        nosubheader = true, # Remove the type from the column names
+        tf = tf_html_default, # Use the default HTML rendered
+        alignment = :c, # Center alignment
+        formatters = (x, i, j) -> Franklin.md2html(x, stripp = true), # Convert every inner cell to html
+        allow_html_in_cells = true, # needed given the previous rendering
+    )
+end


### PR DESCRIPTION
This adds a small section in the demo section about rendering tables as HTML.