### PR TITLE
add dependabot dependency updater for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'


### PR DESCRIPTION
This adds a `dependabot.yml` file. Dependabot is a tool which automatically keeps the github actions used in the workflow files up-to-date.
See [GitHub Docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) for more information.

You can just close this PR if you don't want it.