### PR TITLE
update compathelper

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -2,25 +2,20 @@ name: CompatHelper
 
 on:
   schedule:
-    - cron: '00 * * * *'
-  issues:
-    types: [opened, reopened]
+    - cron: 0 0 * * 5
+  workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        julia-version: [1.2.0]
-        julia-arch: [x86]
-        os: [ubuntu-latest]
+  CompatHelper:
+    runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/setup-julia@latest
+      - name: Set up Julia
+        uses: julia-actions/setup-julia@latest
         with:
-          version: ${{ matrix.julia-version }}
-      - name: Pkg.add("CompatHelper")
+          version: 1
+      - name: Set up CompatHelper
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: CompatHelper.main()
+      - name: Run CompatHelper
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: julia -e 'using CompatHelper; CompatHelper.main()'


### PR DESCRIPTION
This changes compathelper to only run every friday at 12am or if manually triggered (which is what the workflow_dispatch trigger does).

There also one functional change. It now runs always on the latest julia version instead of 1.2.0. I'm not sure if this has any (bad) consequences.