### PR TITLE
Sitemap fix for 404.md

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.10.82"
+version = "0.10.83"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/manager/dir_utils.jl
+++ b/src/manager/dir_utils.jl
@@ -66,8 +66,8 @@ function _keep_path(base, fname)::Bool
     rpath = get_rpath(joinpath(base, fname))
     keep  = union(globvar(:keep_path)::Vector{String}, ["404.html", "404"])
     isempty(keep) && return false
-    files = [f for f in keep if endswith(f, ".html")]
-    dirs = [d for d in keep if endswith(d, "/")]
+    files = [f for f in keep if endswith(f, ".html") || f == "404"]
+    dirs  = [d for d in keep if endswith(d, "/")]
     spath = rpath * ".html"
     any(f -> f == spath, files) && return true
     any(d -> startswith(spath, d), dirs) && return true

--- a/src/manager/dir_utils.jl
+++ b/src/manager/dir_utils.jl
@@ -64,7 +64,7 @@ end
 
 function _keep_path(base, fname)::Bool
     rpath = get_rpath(joinpath(base, fname))
-    keep  = union(globvar(:keep_path)::Vector{String}, ["404.html"])
+    keep  = union(globvar(:keep_path)::Vector{String}, ["404.html", "404"])
     isempty(keep) && return false
     files = [f for f in keep if endswith(f, ".html")]
     dirs = [d for d in keep if endswith(d, "/")]

--- a/src/manager/sitemap_generator.jl
+++ b/src/manager/sitemap_generator.jl
@@ -44,6 +44,7 @@ Add an entry to `SITEMAP_DICT`.
 """
 function add_sitemap_item(; html=false)
     loc = url_curpage()
+    endswith(loc, "404.html") && return nothing
     locvar(:sitemap_exclude)::Bool && return nothing
     if !html
         lastmod = locvar(:fd_mtime_raw)

--- a/src/utils/html.jl
+++ b/src/utils/html.jl
@@ -125,7 +125,7 @@ Helper function to get the relative url of the current page.
 function url_curpage()
     # get the relative path to current page and split extension (.md)
     rpath = locvar(:fd_rpath)
-    keep  = union(globvar(:keep_path)::Vector{String}, ["404.html"])
+    keep  = union(globvar(:keep_path)::Vector{String}, ["404.html", "404"])
     rpath in keep && return rpath
 
     fn, ext = splitext(rpath)

--- a/src/utils/html.jl
+++ b/src/utils/html.jl
@@ -125,8 +125,8 @@ Helper function to get the relative url of the current page.
 function url_curpage()
     # get the relative path to current page and split extension (.md)
     rpath = locvar(:fd_rpath)
-    keep  = union(globvar(:keep_path)::Vector{String}, ["404.html", "404"])
-    rpath in keep && return rpath
+    keep  = union(globvar(:keep_path)::Vector{String}, ["404.html", "404.md"])
+    rpath in keep && return replace(rpath, r"\.md$" => ".html")
 
     fn, ext = splitext(rpath)
     if ext != ".html"


### PR DESCRIPTION
Closes #1011 

@fkastner I'd appreciate a double check here; what I did:

```
julia> newsite(".")
julia> # added generate_sitemap = true in config.md
julia> serve(single=true)
shell> cat __site/sitemap.xml
(...)
<url>
    <loc>https://tlienart.github.io/FranklinTemplates.jl/404.html</loc>
    <lastmod>2023-05-09</lastmod>
    <changefreq>monthly</changefreq>
    <priority>0.5</priority>
</url>
(...)
```

thanks for the report!