### PR TITLE
Fix an issue with extension-less files to ignore that don't start with a '.'

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.10.84"
+version = "0.10.85"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/eval/io.jl
+++ b/src/eval/io.jl
@@ -11,15 +11,17 @@ $(SIGNATURES)
 Internal function to take a relative path and return a unix version of the path
 (if it isn't already). Used in [`resolve_rpath`](@ref).
 """
-function unixify(rpath::AS)::AS
+function unixify(rpath::AS; allow_noext::Bool=false)::AS
     # if empty, return "/"
     isempty(rpath) && return "/"
     # if windows, replace "\\" by "/"
     Sys.isunix() || (rpath = replace(rpath, "\\" => "/"))
     # if it's a path to a dot file, like path/.gitignore, return (issue #1001)
-    startswith(splitdir(rpath)[2], ".") && return rpath
+    startswith(splitdir(rpath)[2], ".") && return rpath  
     # if it has an extension e.g.: /blah.txt, return
     isempty(splitext(rpath)[2]) || return rpath
+    # if an extension-less path is allowed, return (issue #1031)
+    allow_noext && return rpath
     # if it doesn't have an extension, check if it ends with `/` e.g. : /blah/
     # if it doesn't end with "/", add one and return
     endswith(rpath, "/") || return rpath * "/"

--- a/src/manager/dir_utils.jl
+++ b/src/manager/dir_utils.jl
@@ -212,7 +212,8 @@ Rules:
 function should_ignore(fpath::AS, files2ignore::Vector,
                        dirs2ignore::Vector)::Bool
     # fpath is necessarily an absolute path so can strip the folder part
-    fpath = fpath[length(path(:folder))+length(PATH_SEP)+1:end] |> unixify
+    fpath = fpath[length(path(:folder))+length(PATH_SEP)+1:end]
+    fpath = unixify(fpath; allow_noext=true)
     if any(c -> c isa Regex ? match(c, fpath) !== nothing : c == fpath,
                files2ignore)
         return true


### PR DESCRIPTION
fixes an issue with file paths to ignore when the file has no extension the issue was due to  trying to add a  when it got a path that did not start with a  and that did not have an extension already (this is incidentally why this wasn't flagged for )

closes #1031 