### PR TITLE
REPL mode for code blocks

### DIFF
--- a/docs/code/index.md
+++ b/docs/code/index.md
@@ -328,11 +328,12 @@ gives
 st
 ```
 
-_Shell mode_ :
+_Shell mode_ : (**note**: in a multi-line setting, each line is assumed to be a separate command)
 
 ````
 ```;
 echo "hello!"
+date
 ```
 ````
 
@@ -340,6 +341,7 @@ gives
 
 ```;
 echo "hello!"
+date
 ```
 
 ~~~

--- a/docs/code/index.md
+++ b/docs/code/index.md
@@ -312,6 +312,78 @@ x = 5
 y = x^2
 ```
 
+**Shell, Pkg, Help**, these modes are also experimentally supported:
+
+_Pkg mode_ :
+
+````
+```]
+st
+```
+````
+
+gives
+
+```]
+st
+```
+
+_Shell mode_ :
+
+````
+```;
+echo "hello!"
+```
+````
+
+gives 
+
+```;
+echo "hello!"
+```
+
+~~~
+<style>
+.julia-help {
+    background-color: #fffee0;
+    padding: 10px;
+    font-style: italic;
+}
+.julia-help h1,h2,h3 {
+    font-size: 1em;
+    font-weight: 500;
+}
+</style>
+~~~
+
+_Help mode_ :
+
+````
+```?
+im
+```
+````
+
+```?
+im
+```
+
+**Note**: for the `help` mode above, the output is HTML corresponding to the julia
+docs, it's wrapped in a `julia-help` div which you should style, the above style
+for instance corresponds to the following CSS:
+
+```css
+.julia-help {
+    background-color: #fffee0;
+    padding: 10px;
+    font-style: italic;
+}
+.julia-help h1,h2,h3 {
+    font-size: 1em;
+    font-weight: 500;
+}
+```
+
 ### Troubleshooting
 
 A few things can go wrong when attempting to use and evaluate code blocks.

--- a/docs/code/index.md
+++ b/docs/code/index.md
@@ -358,7 +358,7 @@ date
 </style>
 ~~~
 
-_Help mode_ :
+_Help mode_ : (**note**: only single line cell blocks will work properly)
 
 ````
 ```?

--- a/docs/code/index.md
+++ b/docs/code/index.md
@@ -277,6 +277,41 @@ savefig(joinpath(@OUTPUT, "sinc.svg")) # hide
 
 **Note**: If you wish to use `Plots.jl` and deploy to GitHub pages, you will need to modify the `.github/workflows/Deploy.yml` by adding `env: GKSwstype: "100"` before the ` - name: Build and Deploy` line. [Here](https://github.com/storopoli/Bayesian-Julia/blob/master/.github/workflows/Deploy.yml) is an example.
 
+### Auto and REPL mode
+
+You can use `!` and `>` to indicate respectively a code that should be run automatically
+and the output appended immediately after, or the same but with a REPL-style display:
+
+````plaintext
+```!
+x = 5
+y = x^2
+```
+````
+
+for instance gives:
+
+```!
+x = 5
+y = x^2
+```
+
+In a similar way:
+
+````plaintext
+```>
+x = 5
+y = x^2
+```
+````
+
+gives
+
+```>
+x = 5
+y = x^2
+```
+
 ### Troubleshooting
 
 A few things can go wrong when attempting to use and evaluate code blocks.

--- a/src/converter/markdown/blocks.jl
+++ b/src/converter/markdown/blocks.jl
@@ -14,8 +14,11 @@ function convert_block(β::AbstractBlock, lxdefs::Vector{LxDef})::AS
 
     βn == :CODE_INLINE     && return html_code_inline(stent(β) |> htmlesc)
     βn == :CODE_BLOCK_LANG && return resolve_code_block(β.ss)
-    βn == :CODE_BLOCK!     && return resolve_code_block(β.ss, shortcut=true)
-    βn == :CODE_REPL       && return resolve_code_block(β.ss, repl=true)
+    βn == :CODE_BLOCK!     && return resolve_code_block(β.ss; shortcut=true)
+    βn == :CODE_REPL       && return resolve_code_block(β.ss; repl=true)
+    βn == :CODE_PKG        && return resolve_code_block(β.ss; pkg=true)
+    βn == :CODE_HELP       && return resolve_code_block(β.ss; help=true)
+    βn == :CODE_SHELL      && return resolve_code_block(β.ss; shell=true)
     βn == :CODE_BLOCK      && return html_code(stent(β), "{{fill lang}}")
     βn == :CODE_BLOCK_IND  && return convert_indented_code_block(β.ss)
 

--- a/src/converter/markdown/blocks.jl
+++ b/src/converter/markdown/blocks.jl
@@ -15,6 +15,7 @@ function convert_block(β::AbstractBlock, lxdefs::Vector{LxDef})::AS
     βn == :CODE_INLINE     && return html_code_inline(stent(β) |> htmlesc)
     βn == :CODE_BLOCK_LANG && return resolve_code_block(β.ss)
     βn == :CODE_BLOCK!     && return resolve_code_block(β.ss, shortcut=true)
+    βn == :CODE_REPL       && return resolve_code_block(β.ss, repl=true)
     βn == :CODE_BLOCK      && return html_code(stent(β), "{{fill lang}}")
     βn == :CODE_BLOCK_IND  && return convert_indented_code_block(β.ss)
 

--- a/src/eval/codeblock.jl
+++ b/src/eval/codeblock.jl
@@ -178,7 +178,7 @@ function resolve_code_block(
                 end
             end
             push!(repl_code_chunks,
-                code => read(a, String)
+                code => String(strip(read(a, String)))
             )
 
         elseif pkg

--- a/src/eval/codeblock.jl
+++ b/src/eval/codeblock.jl
@@ -191,6 +191,7 @@ function resolve_code_block(
         elseif pkg
             for line in split(code, '\n', keepempty=false)
                 a = tempname()
+                pname = splitpath(Pkg.project().path)[end-1]
                 open(a, "w") do outf
                     redirect_stdout(outf) do
                         redirect_stderr(outf) do
@@ -199,7 +200,7 @@ function resolve_code_block(
                     end
                 end
                 push!(repl_code_chunks,
-                    line => String(strip(read(a, String))) * "\n"
+                    "($(pname)) pkg> " * line => String(strip(read(a, String))) * "\n"
                 )
             end
 

--- a/src/eval/codeblock.jl
+++ b/src/eval/codeblock.jl
@@ -174,15 +174,19 @@ function resolve_code_block(
         # and should be considered experimental
 
         elseif shell
-            a = tempname()
-            open(a, "w") do outf
-                redirect_stdout(outf) do
-                    Base.repl_cmd(Cmd(string.(split(code))), nothing)
+            for line in split(code, '\n', keepempty=false)
+                a = tempname()
+                open(a, "w") do outf
+                    redirect_stdout(outf) do
+                        redirect_stderr(outf) do
+                            Base.repl_cmd(Cmd(string.(split(line))), nothing)
+                        end
+                    end
                 end
+                push!(repl_code_chunks,
+                    line => String(strip(read(a, String))) * "\n"
+                )
             end
-            push!(repl_code_chunks,
-                code => String(strip(read(a, String)))
-            )
 
         elseif pkg
             # NOTE: this is very elementary, doesn't consider any `--` arguments

--- a/src/eval/codeblock.jl
+++ b/src/eval/codeblock.jl
@@ -209,7 +209,8 @@ function resolve_code_block(
             push!(repl_code_chunks,
                 code => replace(Markdown.html(r),
                     "<a href=\"@ref\">" => "",
-                    "</code></a>" => "</code>"
+                    "</code></a>" => "</code>",
+                    "language-jldoctest" => "language-julia-repl"
                 )
             )
 

--- a/src/eval/codeblock.jl
+++ b/src/eval/codeblock.jl
@@ -9,8 +9,8 @@ $SIGNATURES
 Take a fenced code block and return a tuple with the language, the relative
 path (if any) and the code.
 """
-function parse_fenced_block(ss::SubString, shortcut=false)::Tuple
-    if shortcut
+function parse_fenced_block(ss::SubString; shortcut=false, repl=false)::Tuple
+    if shortcut || repl
         lang  = locvar(:lang)::String
         cntr  = locvar(:fd_evalc)::Int
         rpath = "_ceval_$cntr"
@@ -86,9 +86,9 @@ Helper function to process the content of a code block.
 Return the html corresponding to the code block, possibly after having
 evaluated the code.
 """
-function resolve_code_block(ss::SubString; shortcut=false)::String
+function resolve_code_block(ss::SubString; shortcut=false, repl=false)::String
     # 1. what kind of code is it
-    lang, rpath, code = parse_fenced_block(ss, shortcut)
+    lang, rpath, code = parse_fenced_block(ss; shortcut, repl)
     # 1.a if no rpath is given, code should not be evaluated
     isnothing(rpath) && return html_code(code, lang)
     # 1.b if not julia code, eval is not supported
@@ -105,10 +105,11 @@ function resolve_code_block(ss::SubString; shortcut=false)::String
     # languages, can't do the module trick so will need to keep track
     # of that virtually. There will need to be a branching over lang=="julia"
     # vs rest here.
+    repl_code_chunks = Pair{String,String}[]
 
     # 2. here we have Julia code, assess whether to run it or not
     # if not, just return the code as a html block
-    if should_eval(code, rpath)
+    if shortcut || repl || should_eval(code, rpath)
         # 3. here we have code that should be (re)evaluated
         # >> retrieve the modulename, the module may not exist
         # (& may not need to)
@@ -117,6 +118,7 @@ function resolve_code_block(ss::SubString; shortcut=false)::String
         mod = ismodule(modname) ?
                 getfield(Main, Symbol(modname)) :
                 newmodule(modname)
+        
         # >> retrieve the code paths
         cp = form_codepaths(rpath)
         # >> write the code to file
@@ -129,22 +131,54 @@ function resolve_code_block(ss::SubString; shortcut=false)::String
         out = ifelse(locvar(:auto_code_path)::Bool, cp.out_dir, bk)
         isdir(out) || mkpath(out)
         cd(out)
-        # >> eval the code in the relevant module (this creates output/)
-        res = run_code(mod, code, cp.out_path; strip_code=false)
-        cd(bk)
-        # >> write res to file
-        # >> this weird thing with QuoteNode is to make sure that the proper
-        #    "show" method is called...
-        io = IOBuffer()
-        Core.eval(mod, quote show($(io), "text/plain", $(QuoteNode(res))) end)
-        write(cp.res_path, take!(io))
+
+        if repl
+            # imitating https://github.com/JuliaLang/julia/blob/fe2eeadc0b382508bef7e77ab517789ea844e708/stdlib/REPL/src/REPL.jl#L429-L430
+            chunk_code = ""
+            chunk_ast = nothing
+            for line in split(code, r"\r?\n", keepempty=false)
+                chunk_code *= line * "\n"
+                chunk_ast   = Base.parse_input_line(chunk_code)
+                if (isa(chunk_ast, Expr) && chunk_ast.head === :incomplete)
+                    continue
+                else
+                    # we have a complete chunk of code
+                    # >> eval the code in the relevant module (this creates output/)
+                    res = run_code(mod, chunk_code, cp.out_path; strip_code=false)
+                    cd(bk)
+                    # >> write res to string (see further down)
+                    io = IOBuffer()
+                    Core.eval(mod, quote show($(io), "text/plain", $(QuoteNode(res))) end)
+                    push!(repl_code_chunks,
+                        chunk_code => String(take!(io))
+                    )
+                    # reset for the next chunk
+                    chunk_code = ""
+                    chunk_ast = nothing
+                end
+            end
+        else
+            # >> eval the code in the relevant module (this creates output/)
+            res = run_code(mod, code, cp.out_path; strip_code=false)
+            cd(bk)
+            # >> write res to file
+            # >> this weird thing with QuoteNode is to make sure that the proper
+            #    "show" method is called...
+            io = IOBuffer()
+            Core.eval(mod, quote show($(io), "text/plain", $(QuoteNode(res))) end)
+            write(cp.res_path, take!(io))
+        end
         # >> since we've evaluated a code block, toggle scope as stale
         set_var!(LOCAL_VARS, "fd_eval", true)
     end
-    # >> finally return as html
-    if locvar(:showall)::Bool || shortcut
+    # >> finally return as html either with or without output
+    # --- with
+    if repl
+        return html_repl_code(repl_code_chunks)
+    elseif shortcut || locvar(:showall)::Bool
         return html_code(code, lang) *
                 reprocess("\\show{$rpath}", [GLOBAL_LXDEFS["\\show"]])
     end
+    # --- without
     return html_code(code, lang)
 end

--- a/src/eval/codeblock.jl
+++ b/src/eval/codeblock.jl
@@ -158,8 +158,11 @@ function resolve_code_block(
                     # >> write res to string (see further down)
                     io = IOBuffer()
                     Core.eval(mod, quote show($(io), "text/plain", $(QuoteNode(res))) end)
+                    stdout_str = read(cp.out_path, String)
+                    res_str = String(take!(io))
+                    res_str = ifelse(res_str == "nothing", "", res_str * "\n")
                     push!(repl_code_chunks,
-                        chunk_code => String(take!(io))
+                        chunk_code => stdout_str * res_str
                     )
                     # reset for the next chunk
                     chunk_code = ""

--- a/src/manager/franklin.jl
+++ b/src/manager/franklin.jl
@@ -109,6 +109,7 @@ function serve(; clear::Bool             = false,
     if isfile(joinpath(FOLDER_PATH[], "Project.toml"))
         Pkg.activate(".")
         flag_env = true
+        set_var!(GLOBAL_VARS, "_has_base_project", true)
     end
 
     # construct the set of files to watch

--- a/src/manager/franklin.jl
+++ b/src/manager/franklin.jl
@@ -106,6 +106,7 @@ function serve(; clear::Bool             = false,
 
     # check if a Project.toml file is available, if so activate the folder
     flag_env = false
+
     if isfile(joinpath(FOLDER_PATH[], "Project.toml"))
         Pkg.activate(".")
         flag_env = true
@@ -211,11 +212,14 @@ function fd_fullpass(watched_files::NamedTuple, join_to_prepath::String="")::Int
     # reset global page variables and latex definitions
     # NOTE: need to keep track of pre-path if specified, see optimize
     prepath = get(GLOBAL_VARS, "prepath", "")
+    has_base_project = globvar(:_has_base_project)
+
     def_GLOBAL_VARS!()
     def_GLOBAL_LXDEFS!()
     empty!.((RSS_ITEMS, SITEMAP_DICT))
     # reinsert prepath if specified
     isempty(prepath) || (GLOBAL_VARS["prepath"] = prepath)
+    set_var!(GLOBAL_VARS, "_has_base_project", has_base_project)
 
     # process configuration file (see also `process_mddefs!`)
     # note the order (utils the config) is important, see also #774

--- a/src/manager/write_page.jl
+++ b/src/manager/write_page.jl
@@ -174,6 +174,19 @@ function convert_and_write(root::String, file::String, head::String,
     # conversion
     content = convert_md(read(fpath, String))
 
+    # check if the active project has changed, if so change it back
+    blackhole = IOBuffer()
+    if globvar(:_has_base_project)::Bool
+        if Pkg.project().path != joinpath(FOLDER_PATH[], "Project.toml")
+            Pkg.activate(".", io=blackhole)
+        end
+    else
+        if isnothing(match(r"v\d\.\d+", splitpath(Pkg.project().path)[end-1]))
+            Pkg.activate(io=blackhole)
+        end
+    end
+
+
     # adding document variables to the dictionary
     # note that some won't change and so it's not necessary to do this every
     # time but it takes negligible time to do this so ¯\_(ツ)_/¯

--- a/src/parser/markdown/tokens.jl
+++ b/src/parser/markdown/tokens.jl
@@ -88,15 +88,16 @@ const MD_TOKENS = LittleDict{Char, Vector{TokenFinder}}(
     '`'  => [ isexactly("`",  ('`',), false)  => :CODE_SINGLE, # `⎵
               isexactly("``", ('`',), false)  => :CODE_DOUBLE, # ``⎵*
               # 3+ can be named
-              isexactly("```",   SPACE_CHAR) => :CODE_TRIPLE, # ```⎵*
-              isexactly("```!",  SPACE_CHAR) => :CODE_TRIPLE!,# ```!⎵*
-              is_language(3)                 => :CODE_LANG3,  # ```lang*
-              isexactly("````",  SPACE_CHAR) => :CODE_QUAD,   # ````⎵*
-              is_language(4)                 => :CODE_LANG4,  # ````lang*
-              isexactly("`````", SPACE_CHAR) => :CODE_PENTA,  # `````⎵*
-              is_language(5)                 => :CODE_LANG5,  # `````lang*
+              isexactly("```",   SPACE_CHAR) => :CODE_TRIPLE,  # ```⎵*
+              isexactly("```!",  SPACE_CHAR) => :CODE_TRIPLE!, # ```!⎵*
+              isexactly("```>",  SPACE_CHAR) => :CODE_REPL,    # ```>⎵*
+              is_language(3)                 => :CODE_LANG3,   # ```lang*
+              isexactly("````",  SPACE_CHAR) => :CODE_QUAD,    # ````⎵*
+              is_language(4)                 => :CODE_LANG4,   # ````lang*
+              isexactly("`````", SPACE_CHAR) => :CODE_PENTA,   # `````⎵*
+              is_language(5)                 => :CODE_LANG5,   # `````lang*
              ],
-    '*'  => [ incrlook(is_hr3)   => :HORIZONTAL_RULE,
+    '*'  => [ incrlook(is_hr3) => :HORIZONTAL_RULE,
              ]
     ) # end dict
 #= NOTE
@@ -148,6 +149,7 @@ const MD_OCB = [
     OCProto(:CODE_BLOCK_LANG, :CODE_LANG4,   (:CODE_QUAD,)    ),
     OCProto(:CODE_BLOCK_LANG, :CODE_LANG5,   (:CODE_PENTA,)   ),
     OCProto(:CODE_BLOCK!,     :CODE_TRIPLE!, (:CODE_TRIPLE,)  ),
+    OCProto(:CODE_REPL,       :CODE_REPL,    (:CODE_TRIPLE,)  ),
     OCProto(:CODE_BLOCK,      :CODE_TRIPLE,  (:CODE_TRIPLE,)  ),
     OCProto(:CODE_BLOCK,      :CODE_QUAD,    (:CODE_QUAD,)    ),
     OCProto(:CODE_BLOCK,      :CODE_PENTA,   (:CODE_PENTA,)   ),
@@ -256,7 +258,13 @@ CODE_BLOCKS_NAMES
 
 List of names of code blocks environments.
 """
-const CODE_BLOCKS_NAMES = (:CODE_BLOCK_LANG, :CODE_BLOCK, :CODE_BLOCK!, :CODE_BLOCK_IND)
+const CODE_BLOCKS_NAMES = (
+    :CODE_BLOCK_LANG,
+    :CODE_BLOCK,
+    :CODE_BLOCK!,
+    :CODE_REPL,
+    :CODE_BLOCK_IND
+)
 
 """
     MD_CLOSEP

--- a/src/parser/markdown/tokens.jl
+++ b/src/parser/markdown/tokens.jl
@@ -87,10 +87,13 @@ const MD_TOKENS = LittleDict{Char, Vector{TokenFinder}}(
              ],
     '`'  => [ isexactly("`",  ('`',), false)  => :CODE_SINGLE, # `⎵
               isexactly("``", ('`',), false)  => :CODE_DOUBLE, # ``⎵*
-              # 3+ can be named
               isexactly("```",   SPACE_CHAR) => :CODE_TRIPLE,  # ```⎵*
               isexactly("```!",  SPACE_CHAR) => :CODE_TRIPLE!, # ```!⎵*
               isexactly("```>",  SPACE_CHAR) => :CODE_REPL,    # ```>⎵*
+              isexactly("```?",  SPACE_CHAR) => :CODE_HELP,    # ```?⎵*
+              isexactly("```;",  SPACE_CHAR) => :CODE_SHELL,   # ```;⎵*
+              isexactly("```]",  SPACE_CHAR) => :CODE_PKG,     # ```]⎵*
+              # 3+ can be named
               is_language(3)                 => :CODE_LANG3,   # ```lang*
               isexactly("````",  SPACE_CHAR) => :CODE_QUAD,    # ````⎵*
               is_language(4)                 => :CODE_LANG4,   # ````lang*
@@ -150,6 +153,9 @@ const MD_OCB = [
     OCProto(:CODE_BLOCK_LANG, :CODE_LANG5,   (:CODE_PENTA,)   ),
     OCProto(:CODE_BLOCK!,     :CODE_TRIPLE!, (:CODE_TRIPLE,)  ),
     OCProto(:CODE_REPL,       :CODE_REPL,    (:CODE_TRIPLE,)  ),
+    OCProto(:CODE_HELP,       :CODE_HELP,    (:CODE_TRIPLE,)  ),
+    OCProto(:CODE_SHELL,      :CODE_SHELL,   (:CODE_TRIPLE,)  ),
+    OCProto(:CODE_PKG,        :CODE_PKG,     (:CODE_TRIPLE,)  ),
     OCProto(:CODE_BLOCK,      :CODE_TRIPLE,  (:CODE_TRIPLE,)  ),
     OCProto(:CODE_BLOCK,      :CODE_QUAD,    (:CODE_QUAD,)    ),
     OCProto(:CODE_BLOCK,      :CODE_PENTA,   (:CODE_PENTA,)   ),
@@ -263,6 +269,9 @@ const CODE_BLOCKS_NAMES = (
     :CODE_BLOCK,
     :CODE_BLOCK!,
     :CODE_REPL,
+    :CODE_HELP,
+    :CODE_PKG,
+    :CODE_SHELL,
     :CODE_BLOCK_IND
 )
 

--- a/src/regexes.jl
+++ b/src/regexes.jl
@@ -69,7 +69,7 @@ const FN_DEF_PAT = r"^\[\^[\p{L}0-9_]+\](:)?$"
 CODE blocks
 ===================================================== =#
 
-const CODE_3!_PAT = r"```\!\s*\n?((?:.|\n)*)```"
+const CODE_3!_PAT = r"```(?:\!|\>)\s*\n?((?:.|\n)*)```"
 
 const CODE_3_PAT = Regex(
         "```([a-zA-Z][a-zA-Z-]*)" *    # language

--- a/src/regexes.jl
+++ b/src/regexes.jl
@@ -69,7 +69,7 @@ const FN_DEF_PAT = r"^\[\^[\p{L}0-9_]+\](:)?$"
 CODE blocks
 ===================================================== =#
 
-const CODE_3!_PAT = r"```(?:\!|\>)\s*\n?((?:.|\n)*)```"
+const CODE_3!_PAT = r"```(?:[\!\>\?\;\]])\s*\n?((?:.|\n)*)```"
 
 const CODE_3_PAT = Regex(
         "```([a-zA-Z][a-zA-Z-]*)" *    # language

--- a/src/utils/html.jl
+++ b/src/utils/html.jl
@@ -119,7 +119,7 @@ function html_repl_code(chunks::Vector{Pair{String,String}}, s::Symbol)::String
     print(io, "<pre><code class=\"language-julia-repl\">")
     prefix = s == :repl ? "julia> " :
              s == :help ? "help?> " :
-             s == :pkg ? "($(splitpath(Pkg.project().path)[end-1])) pkg> " :
+             s == :pkg ? "" : # the project name is recuperated in resolve_block
              "shell> "
     if s == :help
         code, result = chunks[1]

--- a/src/utils/html.jl
+++ b/src/utils/html.jl
@@ -116,7 +116,7 @@ html_code_inline(c::AS) = "<code>$c</code>"
 function html_repl_code(chunks::Vector{Pair{String,String}})::String
     isempty(chunks) && return ""
     io = IOBuffer()
-    println(io, "<pre><code class=\"language-julia-repl\">")
+    print(io, "<pre><code class=\"language-julia-repl\">")
     for (code, result) in chunks
         println(io, "julia> " * htmlesc(strip(code)))
         println(io, result)

--- a/src/utils/html.jl
+++ b/src/utils/html.jl
@@ -116,7 +116,7 @@ html_code_inline(c::AS) = "<code>$c</code>"
 function html_repl_code(chunks::Vector{Pair{String,String}})::String
     isempty(chunks) && return ""
     io = IOBuffer()
-    println(io, "<pre><code class=\"language-julia julia-repl\">")
+    println(io, "<pre><code class=\"language-julia-repl\">")
     for (code, result) in chunks
         println(io, "julia> " * htmlesc(strip(code)))
         println(io, result)

--- a/src/utils/html.jl
+++ b/src/utils/html.jl
@@ -109,6 +109,23 @@ Convenience function to introduce inline code.
 """
 html_code_inline(c::AS) = "<code>$c</code>"
 
+
+"""
+    html_repl_code
+"""
+function html_repl_code(chunks::Vector{Pair{String,String}})::String
+    isempty(chunks) && return ""
+    io = IOBuffer()
+    println(io, "<pre><code class=\"language-julia julia-repl\">")
+    for (code, result) in chunks
+        println(io, "julia> " * htmlesc(strip(code)))
+        println(io, result)
+    end
+    println(io, "</code></pre>")
+    return String(take!(io))
+end
+
+
 """
     html_err
 

--- a/src/utils/html.jl
+++ b/src/utils/html.jl
@@ -113,15 +113,28 @@ html_code_inline(c::AS) = "<code>$c</code>"
 """
     html_repl_code
 """
-function html_repl_code(chunks::Vector{Pair{String,String}})::String
+function html_repl_code(chunks::Vector{Pair{String,String}}, s::Symbol)::String
     isempty(chunks) && return ""
     io = IOBuffer()
     print(io, "<pre><code class=\"language-julia-repl\">")
-    for (code, result) in chunks
-        println(io, "julia> " * htmlesc(strip(code)))
+    prefix = s == :repl ? "julia> " :
+             s == :help ? "help?> " :
+             s == :pkg ? "pkg> " :
+             "shell> "
+    if s == :help
+        code, result = chunks[1]
+        println(io, prefix * htmlesc(strip(code)))
+        println(io, "</code></pre>")
+        println(io, "<div class=\"julia-help\">")
         println(io, result)
+        println(io, "</div>")
+    else
+        for (code, result) in chunks
+            println(io, prefix * htmlesc(strip(code)))
+            println(io, result)
+        end
+        println(io, "</code></pre>")
     end
-    println(io, "</code></pre>")
     return String(take!(io))
 end
 

--- a/src/utils/html.jl
+++ b/src/utils/html.jl
@@ -119,7 +119,7 @@ function html_repl_code(chunks::Vector{Pair{String,String}}, s::Symbol)::String
     print(io, "<pre><code class=\"language-julia-repl\">")
     prefix = s == :repl ? "julia> " :
              s == :help ? "help?> " :
-             s == :pkg ? "pkg> " :
+             s == :pkg ? "($(splitpath(Pkg.project().path)[end-1])) pkg> " :
              "shell> "
     if s == :help
         code, result = chunks[1]

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -70,6 +70,8 @@ const GLOBAL_VARS_DEFAULT = [
     # -----------------------------------------------------
     # LEGACY
     "div_content" => dpair(""), # see build_page
+    #
+    "_has_base_project" => dpair(false),
     ]
 
 const GLOBAL_VARS_ALIASES = LittleDict(

--- a/test/eval/repl.jl
+++ b/test/eval/repl.jl
@@ -1,4 +1,4 @@
-@testset "parse fenced" begin
+@testset "repl" begin
     s = """
     ```>
     x = 5
@@ -23,4 +23,43 @@
         24
         </code></pre>
         """)
+end
+
+@testset "help" begin
+    s = """
+    ```?
+    im
+    ```
+    """ |> fd2html
+
+    @test occursin("""
+        <pre><code class="language-julia-repl">help?> im
+        </code></pre>
+        <div class="julia-help">
+        <pre><code>im</code></pre>
+        <p>The imaginary unit.</p>
+        """, s)
+end
+
+@testset "shell" begin
+    s = """
+        ```;
+        echo "foo"
+        ```
+        """ |> fd2html
+    @test isapproxstr(s, """
+        <pre><code class="language-julia-repl">shell> echo &quot;foo&quot;
+        "foo"
+        </code></pre>
+        """)
+end
+
+@testset "pkg" begin
+    s = """
+        ```]
+        st
+        ```
+        """ |> fd2html
+    @test occursin("""<pre><code class="language-julia-repl">pkg> st
+    Project Franklin""", s)
 end

--- a/test/eval/repl.jl
+++ b/test/eval/repl.jl
@@ -120,13 +120,13 @@ end
 
     # first block
     @test occursin(
-        """pkg> activate --temp""", s
+        """pkg&gt; activate --temp""", s
     )
     @test occursin(
-        """pkg> add StableRNGs\nResolving package versions...""", s
+        """pkg&gt; add StableRNGs\nResolving package versions...""", s
     )
     @test occursin(
-        """pkg> st\nStatus""", s
+        """pkg&gt; st\nStatus""", s
     )
 
     # second block uses StableRNG

--- a/test/eval/repl.jl
+++ b/test/eval/repl.jl
@@ -11,8 +11,7 @@
     """ |> fd2html
 
     @test isapproxstr(s, """
-        <pre><code class="language-julia-repl">
-        julia> x &#61; 5
+        <pre><code class="language-julia-repl">julia> x &#61; 5
         5
         julia> y &#61; 7 &#43; x
         12

--- a/test/eval/repl.jl
+++ b/test/eval/repl.jl
@@ -108,9 +108,36 @@ end
 @testset "pkg" begin
     s = """
         ```]
+        activate --temp
+        add StableRNGs
         st
         ```
+
+        this is now in the activated stuff
+
+        ```!
+        using StableRNGs
+        round(rand(StableRNG(1)), sigdigits=3)
+        ```
+
         """ |> fd2html
-    @test occursin("""<pre><code class="language-julia-repl">pkg> st""", s)
-    @test occursin("""Status `""", s)
+
+    # first block
+    @test occursin(
+        """pkg> activate --temp""", s
+    )
+    @test occursin(
+        """pkg> add StableRNGs\nResolving package versions...""", s
+    )
+    @test occursin(
+        """pkg> st\nStatus""", s
+    )
+
+    # second block uses StableRNG
+    @test occursin(
+        """<pre><code class="language-julia">using StableRNGs
+        round&#40;rand&#40;StableRNG&#40;1&#41;&#41;, sigdigits&#61;3&#41;</code></pre><pre><code class="plaintext code-output">0.585</code></pre>""",
+        s
+    )
+    Pkg.activate()
 end

--- a/test/eval/repl.jl
+++ b/test/eval/repl.jl
@@ -11,7 +11,7 @@
     """ |> fd2html
 
     @test isapproxstr(s, """
-        <pre><code class="language-julia julia-repl">
+        <pre><code class="language-julia-repl">
         julia> x &#61; 5
         5
         julia> y &#61; 7 &#43; x

--- a/test/eval/repl.jl
+++ b/test/eval/repl.jl
@@ -88,7 +88,6 @@ end
         ```;
         echo abc
         echo "abc"
-        abc -12
         ```
         """ |> fd2html
     @test isapproxstr(s, """
@@ -97,9 +96,6 @@ end
         
         shell> echo &quot;abc&quot;
         "abc"
-        
-        shell> abc -12
-        zsh:1: command not found: abc
         
         </code></pre>
         """)

--- a/test/eval/repl.jl
+++ b/test/eval/repl.jl
@@ -1,0 +1,27 @@
+@testset "parse fenced" begin
+    s = """
+    ```>
+    x = 5
+    y = 7 + x
+    ```
+    some explanation
+    ```>
+    z = y * 2
+    ```
+    """ |> fd2html
+
+    @test isapproxstr(s, """
+        <pre><code class="language-julia julia-repl">
+        julia> x &#61; 5
+        5
+        julia> y &#61; 7 &#43; x
+        12
+        </code></pre>
+        
+        <p>some explanation</p>
+        <pre><code class="language-julia julia-repl">
+        julia> z &#61; y * 2
+        24
+        </code></pre>
+        """)
+end

--- a/test/eval/repl.jl
+++ b/test/eval/repl.jl
@@ -13,16 +13,47 @@
     @test isapproxstr(s, """
         <pre><code class="language-julia-repl">julia> x &#61; 5
         5
+
         julia> y &#61; 7 &#43; x
         12
+
         </code></pre>
         
         <p>some explanation</p>
         <pre><code class="language-julia-repl">
         julia> z &#61; y * 2
         24
+
         </code></pre>
         """)
+    
+    s = """
+    ```>
+    println("hello")
+    x = 5
+    ```
+    """ |> fd2html
+    @test isapproxstr(s, """
+        <pre><code class="language-julia-repl">julia> println&#40;&quot;hello&quot;&#41;
+        hello
+        
+        julia> x &#61; 5
+        5
+        
+        </code></pre>
+        """)
+
+    s = """
+    ```>
+    x = 5;
+    ```
+    """ |> fd2html
+    @test isapproxstr(s, """
+        <pre><code class="language-julia-repl">julia> x &#61; 5;
+
+        </code></pre>
+        """
+    )
 end
 
 @testset "help" begin

--- a/test/eval/repl.jl
+++ b/test/eval/repl.jl
@@ -19,7 +19,7 @@
         </code></pre>
         
         <p>some explanation</p>
-        <pre><code class="language-julia julia-repl">
+        <pre><code class="language-julia-repl">
         julia> z &#61; y * 2
         24
         </code></pre>

--- a/test/eval/repl.jl
+++ b/test/eval/repl.jl
@@ -60,6 +60,6 @@ end
         st
         ```
         """ |> fd2html
-    @test occursin("""<pre><code class="language-julia-repl">pkg> st
-    Project Franklin""", s)
+    @test occursin("""<pre><code class="language-julia-repl">pkg> st""", s)
+    @test occursin("""Status `""", s)
 end

--- a/test/eval/repl.jl
+++ b/test/eval/repl.jl
@@ -83,6 +83,26 @@ end
         "foo"
         </code></pre>
         """)
+    # multiline
+    s = """
+        ```;
+        echo abc
+        echo "abc"
+        abc -12
+        ```
+        """ |> fd2html
+    @test isapproxstr(s, """
+        <pre><code class="language-julia-repl">shell> echo abc
+        abc
+        
+        shell> echo &quot;abc&quot;
+        "abc"
+        
+        shell> abc -12
+        zsh:1: command not found: abc
+        
+        </code></pre>
+        """)
 end
 
 @testset "pkg" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,7 @@ include("eval/codeblock.jl")
 include("eval/eval.jl")
 include("eval/integration.jl")
 include("eval/extras.jl")
+include("eval/repl.jl")
 
 # LATEX
 println("LATEX")


### PR DESCRIPTION
ongoing todo list here: https://github.com/tlienart/Franklin.jl/pull/1035#issuecomment-1628923119

---

Can now do

````
```>
x = 5
y = x * 2
```
some explanation
```>
z = 2y
```
````

and get the following html

```
<pre><code class="language-julia-repl">
julia> x &#61; 5
5
julia> y &#61; x * 2
10
</code></pre>

<p>some explanation</p>
<pre><code class="language-julia-repl">
julia> z &#61; 2y
20
</code></pre>
```

(note `&#61` is `=`)

closes #818 

cc @gdalle , @kescobo 

<img width="470" alt="Screenshot 2023-07-09 at 22 25 49" src="https://github.com/tlienart/Franklin.jl/assets/10897531/0aa6951c-5e5f-4d0f-928e-fae2651d279d">
