### PR TITLE
adjustment to final skipped line in repl mode

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.10.86"
+version = "0.10.87"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/utils/html.jl
+++ b/src/utils/html.jl
@@ -129,10 +129,15 @@ function html_repl_code(chunks::Vector{Pair{String,String}}, s::Symbol)::String
         println(io, result)
         println(io, "</div>")
     else
-        for (code, result) in chunks
+        for (code, result) in chunks[1:end-1]
             println(io, prefix * htmlesc(strip(code)))
             println(io, result)
         end
+        # last chunk; we want to avoid a stray empty line, note the `print`.
+        code, result = chunks[end]
+        println(io, prefix * htmlesc(strip(code)))
+        print(io, result)
+        # close the block
         println(io, "</code></pre>")
     end
     return String(take!(io))


### PR DESCRIPTION
@gdalle fyi this is a tiny change so that REPL blocks don't have a stray empty line, e.g. on

https://gdalle.github.io/ModernJuliaWorkflows/pages/writing/#repl

<img width="301" alt="Screenshot 2023-07-11 at 17 13 11" src="https://github.com/tlienart/Franklin.jl/assets/10897531/5b436779-0840-44ef-9a26-39d31ac15b44">

now: 

<img width="203" alt="Screenshot 2023-07-11 at 17 13 30" src="https://github.com/tlienart/Franklin.jl/assets/10897531/07216503-bfc3-4752-b3cf-eae3e933d1d8">

will be released shortly after CI checks which should be fine