### PR TITLE
adding draft mode

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.10.88"
+version = "0.10.89"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/manager/write_page.jl
+++ b/src/manager/write_page.jl
@@ -86,6 +86,11 @@ function write_page(output_path::AS, content::AS;
     )
     set_var!(LOCAL_VARS, "fd_full_url", full_url)
 
+    if FD_ENV[:FINAL_PASS] && locvar(:draft)
+        isfile(output_path) && rm(output_path)
+        return
+    end
+
     # NOTE
     #   - output_path is assumed to exist // see form_output_path
     #   - head/pgfoot/foot === nothing --> read (see franklin.jl)

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -113,6 +113,7 @@ const LOCAL_VARS_DEFAULT = [
     "tags"          => dpair(String[]),
     "prerender"     => dpair(true),     # allow specific switch
     "slug"          => dpair(""),       # allow specific target url eg: aa/bb/cc
+    "draft"         => dpair(false),    # page will not be generated at built time if true
     # -----------------
     # TABLE OF CONTENTS
     "mintoclevel" => dpair(1),   # set to 2 to ignore h1


### PR DESCRIPTION
cc @limarta (if you could try this and check it works fine for you, I'd be grateful for the feeback)

```
+++
draft = true
+++

# ABC

Some content that you want to see locally but not when deploying
```

if you call `serve()` locally, the page will appear. If you call `optimize(...)` (which would be the case with the github action), that page will not be generated and if there's a file at the output location, it'll be removed. 

closes #1044