### PR TITLE
add sitemap_file as a global option

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.10.89"
+version = "0.10.90"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/manager/robots_generator.jl
+++ b/src/manager/robots_generator.jl
@@ -26,8 +26,9 @@ function robots_generator()
     dst = joinpath(path(:site), "robots.txt")
     isfile(dst) && rm(dst)
     io = IOBuffer()
+    sitemap_file = splitext(globvar(:sitemap_file))[1] * ".xml"
     globvar(:generate_sitemap)::Bool && println(io, """
-        Sitemap: $(joinpath(globvar(:website_url)::String, "sitemap.xml"))
+        Sitemap: $(joinpath(globvar(:website_url)::String, sitemap_file))
         """)
     print(io, """
         User-agent: *

--- a/src/manager/sitemap_generator.jl
+++ b/src/manager/sitemap_generator.jl
@@ -67,7 +67,8 @@ $SIGNATURES
 Generate a `sitemap.xml`, if one already exists, it will be replaced.
 """
 function sitemap_generator()
-    dst = joinpath(path(:site), "sitemap.xml")
+    sitemap_file = splitext(globvar(:sitemap_file))[1] * ".xml"
+    dst = joinpath(path(:site), sitemap_file)
     isfile(dst) && rm(dst)
     io = IOBuffer()
     println(io, """

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -47,6 +47,7 @@ const GLOBAL_VARS_DEFAULT = [
     "rss_full_content"    => dpair(false),
     # Sitemap
     "generate_sitemap" => dpair(true),
+    "sitemap_file"     => dpair("sitemap"),
     # div names
     "content_tag"       => dpair("div"),
     "content_class"     => dpair("franklin-content"),

--- a/src/utils/vars.jl
+++ b/src/utils/vars.jl
@@ -83,6 +83,8 @@ const GLOBAL_VARS_ALIASES = LittleDict(
     "rss_website_url"   => "website_url",
     "rss_website_descr" => "website_description",
     "website_descr"     => "website_description",
+    "rss_filename"      => "rss_file",
+    "sitemap_filename"  => "sitemap_file",
     )
 
 """


### PR DESCRIPTION
@mortenpi would you mind trying this out?

closes #1047 by adding a global variable `sitemap_file` if the user wants something else than `sitemap(.xml)`. 

**config.md**
```
+++
# ... rest
sitemap_file = "mySitemap"
# ... rest
+++
```

--> `mySitemap.xml` will be generated (instead of default `sitemap.xml`)
