### PR TITLE
adding explicit classes for repl mode

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Franklin"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.10.90"
+version = "0.10.91"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/eval/codeblock.jl
+++ b/src/eval/codeblock.jl
@@ -212,7 +212,8 @@ function resolve_code_block(
                 code => replace(Markdown.html(r),
                     r"\<a href=\"@ref(.*?)\"\>" => "",
                     "</code></a>" => "</code>",
-                    "language-jldoctest" => "language-julia-repl"
+                    "language-jldoctest" => "language-julia-repl",
+                    "<pre><code>" => "<pre><code class=\"language-julia\">"
                 )
             )
 

--- a/src/utils/html.jl
+++ b/src/utils/html.jl
@@ -116,7 +116,8 @@ html_code_inline(c::AS) = "<code>$c</code>"
 function html_repl_code(chunks::Vector{Pair{String,String}}, s::Symbol)::String
     isempty(chunks) && return ""
     io = IOBuffer()
-    print(io, "<pre><code class=\"language-julia-repl\">")
+    class = "julia-repl" * ifelse(s == :repl, "", "-$s")
+    print(io, "<pre><code class=\"language-julia-repl $class\">")
     prefix = s == :repl ? "julia> " :
              s == :help ? "help?> " :
              s == :pkg ? "" : # the project name is recuperated in resolve_block

--- a/test/eval/repl.jl
+++ b/test/eval/repl.jl
@@ -67,7 +67,7 @@ end
         <pre><code class="language-julia-repl julia-repl-help">help?> im
         </code></pre>
         <div class="julia-help">
-        <pre><code>im</code></pre>
+        <pre><code class="language-julia">im</code></pre>
         <p>The imaginary unit.</p>
         """, s)
 end

--- a/test/eval/repl.jl
+++ b/test/eval/repl.jl
@@ -11,7 +11,7 @@
     """ |> fd2html
 
     @test isapproxstr(s, """
-        <pre><code class="language-julia-repl">julia> x &#61; 5
+        <pre><code class="language-julia-repl julia-repl">julia> x &#61; 5
         5
 
         julia> y &#61; 7 &#43; x
@@ -20,7 +20,7 @@
         </code></pre>
         
         <p>some explanation</p>
-        <pre><code class="language-julia-repl">
+        <pre><code class="language-julia-repl julia-repl">
         julia> z &#61; y * 2
         24
 
@@ -34,7 +34,7 @@
     ```
     """ |> fd2html
     @test isapproxstr(s, """
-        <pre><code class="language-julia-repl">julia> println&#40;&quot;hello&quot;&#41;
+        <pre><code class="language-julia-repl julia-repl">julia> println&#40;&quot;hello&quot;&#41;
         hello
         
         julia> x &#61; 5
@@ -49,7 +49,7 @@
     ```
     """ |> fd2html
     @test isapproxstr(s, """
-        <pre><code class="language-julia-repl">julia> x &#61; 5;
+        <pre><code class="language-julia-repl julia-repl">julia> x &#61; 5;
 
         </code></pre>
         """
@@ -64,7 +64,7 @@ end
     """ |> fd2html
 
     @test occursin("""
-        <pre><code class="language-julia-repl">help?> im
+        <pre><code class="language-julia-repl julia-repl-help">help?> im
         </code></pre>
         <div class="julia-help">
         <pre><code>im</code></pre>
@@ -79,7 +79,7 @@ end
         ```
         """ |> fd2html
     @test isapproxstr(s, """
-        <pre><code class="language-julia-repl">shell> echo &quot;foo&quot;
+        <pre><code class="language-julia-repl julia-repl-shell">shell> echo &quot;foo&quot;
         "foo"
         </code></pre>
         """)
@@ -91,7 +91,7 @@ end
         ```
         """ |> fd2html
     @test isapproxstr(s, """
-        <pre><code class="language-julia-repl">shell> echo abc
+        <pre><code class="language-julia-repl julia-repl-shell">shell> echo abc
         abc
         
         shell> echo &quot;abc&quot;


### PR DESCRIPTION
closes #1048 

adds classes

* `julia-repl`,
* `julia-repl-shell`
* `julia-repl-help`
* `julia-repl-pkg` 

so that 

````
```>
x = 5
```
````

becomes

```
<pre><code class="language-julia-repl julia-repl">julia> x &#61; 5
5
</code></pre>
```

making it easier to be more specific and have dedicated styling or annotation for repl blocks.