### PR TITLE
Fixed TOC nesting with non-sequential headings

### DIFF
--- a/src/converter/html/functions.jl
+++ b/src/converter/html/functions.jl
@@ -172,20 +172,27 @@ function hfun_toc(params::Vector{String})::String
     isempty(headers) && return ""
     baselvl = minimum(h[3] for h in values(headers)) - 1
     curlvl  = baselvl
+    curskip = curlvl
     for (rs, h) ∈ headers
         lvl = h[3]
+        sep = abs(lvl - curlvl)
+        skipped_lvl = sep ∉ [0, 1]
+        skip = skipped_lvl ? sep - 1 : 0
+        if skip != 0
+            curskip = skip
+        end
         if lvl ≤ curlvl
             # Close previous list item
             inner *= "</li>"
             # Close additional sublists for each level eliminated
-            for i = curlvl-1:-1:lvl
+            for i = fill(nothing, curlvl - lvl - skip)
                 inner *= "</ol></li>"
             end
             # Reopen for this list item
             inner *= "<li>"
         elseif lvl > curlvl
             # Open additional sublists for each level added
-            for i = curlvl+1:lvl
+            for i = fill(nothing, lvl - curlvl - skip)
                 inner *= "<ol><li>"
             end
         end
@@ -194,7 +201,7 @@ function hfun_toc(params::Vector{String})::String
         # At this point, number of sublists (<ol><li>) open equals curlvl
     end
     # Close remaining lists, as if going down to the base level
-    for i = curlvl-1:-1:baselvl
+    for i = fill(nothing, curlvl - baselvl + curskip)
         inner *= "</li></ol>"
     end
     toc = "<div class=\"franklin-toc\">" * inner * "</div>"

--- a/src/converter/html/functions.jl
+++ b/src/converter/html/functions.jl
@@ -185,13 +185,17 @@ function hfun_toc(params::Vector{String})::String
             # Close previous list item
             inner *= "</li>"
             # Close additional sublists for each level eliminated
-            for i = fill(nothing, curlvl - lvl - skip)
+            for i = fill(nothing, curlvl - lvl)
                 inner *= "</ol></li>"
             end
             # Reopen for this list item
             inner *= "<li>"
         elseif lvl > curlvl
             # Open additional sublists for each level added
+            for i = fill(nothing, skip)
+                # hide marker for the empty nested sublists
+                inner *= "<ol><li style=\"list-style-type: none;\">"
+            end
             for i = fill(nothing, lvl - curlvl - skip)
                 inner *= "<ol><li>"
             end

--- a/test/converter/md/markdown2.jl
+++ b/test/converter/md/markdown2.jl
@@ -43,7 +43,7 @@ end
           <ol>
             <li><a href="#hello_fd">Hello <code>fd</code></a>
               <ol>
-                <li>
+                <li style="list-style-type: none;">
                   <ol>
                     <li><a href="#weirdly_nested">weirdly nested</a></li>
                   </ol>

--- a/test/converter/md/markdown2.jl
+++ b/test/converter/md/markdown2.jl
@@ -31,33 +31,74 @@ end
     fs()
     h = raw"""
         @def fd_rpath = "pages/ff/aa.md"
+        @def mintoclevel = 1
+        @def maxtoclevel = 4
         \toc
-        ## Hello `fd`
-        #### weirdly nested
-        ### Goodbye!
-        ## Done
+        ### Part of family 1: should not be nested `fd`
+        ## Top-most ancestor of family 2
+        #### should be empty nested
+        ### part of family 2
+        ## Top-most ancestor of family 3
+        #### child1
+        #### child2
+        #### child3
+        #### child4
+        ## Top-most ancestor of family 4
         done.
         """ |> seval
     @test isapproxstr(h, raw"""
-        <div class="franklin-toc">
+          <div class="franklin-toc">
           <ol>
-            <li><a href="#hello_fd">Hello <code>fd</code></a>
+            <li>
+              <a href="#part_of_family_1_should_not_be_nested_fd">Part of family 1: should not be nested <code>fd</code></a>
+            </li>
+            <li>
+              <a href="#top-most_ancestor_of_family_2">Top-most ancestor of family 2</a>
               <ol>
                 <li style="list-style-type: none;">
                   <ol>
-                    <li><a href="#weirdly_nested">weirdly nested</a></li>
+                    <li>
+                      <a href="#should_be_empty_nested">should be empty nested</a>
+                    </li>
                   </ol>
                 </li>
-                <li><a href="#goodbye">Goodbye&#33;</a></li>
+                <li>
+                  <a href="#part_of_family_2">part of family 2</a>
+                </li>
               </ol>
             </li>
-            <li><a href="#done">Done</a></li>
+            <li>
+              <a href="#top-most_ancestor_of_family_3">Top-most ancestor of family 3</a>
+              <ol>
+                <li>
+                  <a href="#child1">child1</a>
+                </li>
+                <li>
+                  <a href="#child2">child2</a>
+                </li>
+                <li>
+                  <a href="#child3">child3</a>
+                </li>
+                <li>
+                  <a href="#child4">child4</a>
+                </li>
+              </ol>
+            </li>
+            <li>
+              <a href="#top-most_ancestor_of_family_4">Top-most ancestor of family 4</a>
+            </li>
           </ol>
         </div>
-        <h2 id="hello_fd"><a href="#hello_fd" class="header-anchor">Hello <code>fd</code></a></h2>
-        <h4 id="weirdly_nested"><a href="#weirdly_nested" class="header-anchor">weirdly nested</a></h4>
-        <h3 id="goodbye"><a href="#goodbye" class="header-anchor">Goodbye&#33;</a></h3>
-        <h2 id="done"><a href="#done" class="header-anchor">Done</a></h2>
+        <h3 id="part_of_family_1_should_not_be_nested_fd"><a href="#part_of_family_1_should_not_be_nested_fd" class="header-anchor">Part of family 1: should not be nested <code>fd</code></a></h3>
+        <h2 id="top-most_ancestor_of_family_2"><a href="#top-most_ancestor_of_family_2" class="header-anchor">Top-most ancestor of family 2</a></h2>
+        <h4 id="should_be_empty_nested"><a href="#should_be_empty_nested" class="header-anchor">should be empty nested</a></h4>
+        <h3 id="part_of_family_2"><a href="#part_of_family_2" class="header-anchor">part of family 2</a></h3>
+        <h2 id="top-most_ancestor_of_family_3"><a href="#top-most_ancestor_of_family_3" class="header-anchor">Top-most ancestor of family 3</a></h2>
+        <h4 id="child1"><a href="#child1" class="header-anchor">child1</a></h4>
+        <h4 id="child2"><a href="#child2" class="header-anchor">child2</a></h4>
+        <h4 id="child3"><a href="#child3" class="header-anchor">child3</a></h4>
+        <h4 id="child4"><a href="#child4" class="header-anchor">child4</a></h4>
+        <h2 id="top-most_ancestor_of_family_4"><a href="#top-most_ancestor_of_family_4" class="header-anchor">Top-most ancestor of family 4</a></h2>
         <p>done.</p>
         """)
 end


### PR DESCRIPTION
When using `\toc` with a page that has nested headings that are not sequential, you currently get the following (which has h4 elements after h1 elements):

### Before
![franklin-toc-before](https://github.com/tlienart/Franklin.jl/assets/1592413/fd00445d-e169-48f9-9028-bcb7e535dfda)


### After
With this PR, I fix it so you skip adding empty nested lists to the TOC:

![franklin-toc-after](https://github.com/tlienart/Franklin.jl/assets/1592413/868fb2bd-aedf-40cf-baeb-e0cca26d0af5)

# Egregious MWE
Here's a MWE that's pretty egregious: 

## Before
![franklin-toc-agg-before](https://github.com/tlienart/Franklin.jl/assets/1592413/e95543cc-5347-47ec-9989-1eea516880cc)

## After
![franklin-toc-agg-after](https://github.com/tlienart/Franklin.jl/assets/1592413/859d053d-4ca7-4d53-a367-c8c7cf59aa55)

## MWE

Note, this with the following `config.md`
```
mintoclevel = 1
maxtoclevel = 7
```

```markdown
@def title = "TOC Testing"

\toc

# H1

### H3

#### H4

## H2

## H2

##### H5

# H1

###### H6

## H2

## H2

#### H4

# H1

#### H4

#### H4

###### H6

#### H4

#### H4
```