### PR TITLE
Simplify TOC nesting code, fix for #1061

### DIFF
--- a/test/converter/md/markdown2.jl
+++ b/test/converter/md/markdown2.jl
@@ -55,12 +55,8 @@ end
             <li>
               <a href="#top-most_ancestor_of_family_2">Top-most ancestor of family 2</a>
               <ol>
-                <li style="list-style-type: none;">
-                  <ol>
-                    <li>
-                      <a href="#should_be_empty_nested">should be empty nested</a>
-                    </li>
-                  </ol>
+                <li>
+                  <a href="#should_be_empty_nested">should be empty nested</a>
                 </li>
                 <li>
                   <a href="#part_of_family_2">part of family 2</a>
@@ -141,4 +137,99 @@ end
         <h3 id="f"><a href="#f" class="header-anchor">F</a></h3>
         <p>done.</p>
         """)
+end
+
+@testset "TOC-3"  begin
+  fs()
+  s = raw"""
+      @def fd_rpath = "pages/ff/aa.md"
+      @def mintoclevel = 1
+      @def maxtoclevel = 7
+      \toc
+      # H1
+      ### H3
+      #### H4
+      ## H2
+      ## H2
+      ##### H5
+      # H1
+      ### H3
+      ## H2
+      ## H2
+      #### H4
+      # H1
+      #### H4
+      #### H4
+      ###### H6
+      #### H4
+      #### H4
+      """ |> seval
+  @test isapproxstr(s, raw"""
+      <div class="franklin-toc">
+      <ol>
+        <li>
+          <a href="#h1">H1</a>
+          <ol>
+            <li>
+              <a href="#h3">H3</a>
+              <ol>
+                <li><a href="#h4">H4</a></li>
+              </ol>
+            </li>
+            <li><a href="#h2">H2</a></li>
+            <li>
+              <a href="#h2__2">H2</a>
+              <ol>
+                <li><a href="#h5">H5</a></li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+        <li>
+          <a href="#h1__2">H1</a>
+          <ol>
+            <li><a href="#h3__2">H3</a></li>
+            <li><a href="#h2__3">H2</a></li>
+            <li>
+              <a href="#h2__4">H2</a>
+              <ol>
+                <li><a href="#h4__2">H4</a></li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+        <li>
+          <a href="#h1__3">H1</a>
+          <ol>
+            <li><a href="#h4__3">H4</a></li>
+            <li>
+              <a href="#h4__4">H4</a>
+              <ol>
+                <li><a href="#h6">H6</a></li>
+              </ol>
+            </li>
+            <li><a href="#h4__5">H4</a></li>
+            <li><a href="#h4__6">H4</a></li>
+          </ol>
+        </li>
+      </ol>
+    </div>
+    <h1 id="h1"><a href="#h1" class="header-anchor">H1</a></h1>
+    <h3 id="h3"><a href="#h3" class="header-anchor">H3</a></h3>
+    <h4 id="h4"><a href="#h4" class="header-anchor">H4</a></h4>
+    <h2 id="h2"><a href="#h2" class="header-anchor">H2</a></h2>
+    <h2 id="h2__2"><a href="#h2__2" class="header-anchor">H2</a></h2>
+    <h5 id="h5"><a href="#h5" class="header-anchor">H5</a></h5>
+    <h1 id="h1__2"><a href="#h1__2" class="header-anchor">H1</a></h1>
+    <h3 id="h3__2"><a href="#h3__2" class="header-anchor">H3</a></h3>
+    <h2 id="h2__3"><a href="#h2__3" class="header-anchor">H2</a></h2>
+    <h2 id="h2__4"><a href="#h2__4" class="header-anchor">H2</a></h2>
+    <h4 id="h4__2"><a href="#h4__2" class="header-anchor">H4</a></h4>
+    <h1 id="h1__3"><a href="#h1__3" class="header-anchor">H1</a></h1>
+    <h4 id="h4__3"><a href="#h4__3" class="header-anchor">H4</a></h4>
+    <h4 id="h4__4"><a href="#h4__4" class="header-anchor">H4</a></h4>
+    <h6 id="h6"><a href="#h6" class="header-anchor">H6</a></h6>
+    <h4 id="h4__5"><a href="#h4__5" class="header-anchor">H4</a></h4>
+    <h4 id="h4__6"><a href="#h4__6" class="header-anchor">H4</a></h4>
+    """)
 end


### PR DESCRIPTION
I simplified how the TOC nesting occurs and fixed #1061 by recording the `open_lists` so we will guarantee closing the proper number of lists at the end.