### PR TITLE
In case the codeblock regex fails to match, print the codeblock

### DIFF
--- a/src/eval/codeblock.jl
+++ b/src/eval/codeblock.jl
@@ -26,6 +26,9 @@ function parse_fenced_block(ss::SubString, scut=false; shortcut=scut, # scut for
         reg = startswith(ss, "`````") ? CODE_5_PAT :
               startswith(ss, "````")  ? CODE_4_PAT : CODE_3_PAT
         m     = match(reg, ss)
+        if m === nothing
+            throw(ArgumentError("Could not match codeblock:\n$ss"))
+        end
         lang  = m.captures[1]
         rpath = m.captures[2]
         code  = strip(m.captures[3])


### PR DESCRIPTION
With this, I get
```julia
Franklin Warning: in <index.md>
│ Encountered an issue processing 'index.md' in rk/writing/spmd_blog.
│ Verify, then re-start the Franklin server.
│ The error is displayed below:
│ ArgumentError("Could not match codeblock:\n```c++\ntemplate <typename T> constexpr void expm(MutSquarePtrMatrix<T> A) {\n  ptrdiff_t n = ptrdiff_t(A.numRow()), s = 0;\n  SquareMatrix<T> A2{SquareDims<>{{n}}}, U_{SquareDims<>{{n}}};\n  MutSquarePtrMatrix<T> U{U_};\n  if (double nA = opnorm1(A); nA <= 0.015) {\n    A2 << A * A;\n    U << A * (A2 + 60.0 * I);\n    A << 12.0 * A2 + 120.0 * I;\n  } else {\n    SquareMatrix<T> B{SquareDims<>{{n}}};\n    if (nA <= 2.1) {\n      A2 << A * A;\n      containers::TinyVector<double, 5> p0, p1;\n      if (nA > 0.95) {\n        p0 = {1.0, 3960.0, 2162160.0, 302702400.0, 8821612800.0};\n        p1 = {90.0, 110880.0, 3.027024e7, 2.0756736e9, 1.76432256e10};\n      } else if (nA > 0.25) {\n        p0 = {1.0, 1512.0, 277200.0, 8.64864e6};\n        p1 = {56.0, 25200.0, 1.99584e6, 1.729728e7};\n      } else {\n        p0 = {1.0, 420.0, 15120.0};\n        p1 = {30.0, 3360.0, 30240.0};\n      }\n      evalpoly(B, U, A2, p0);\n      U << A * B;\n      evalpoly(A, B, A2, p1);\n    } else {\n      // s = std::max(unsigned(std::ceil(std::log2(nA / 5.4))), 0);\n      s = nA > 5.4 ? log2ceil(nA / 5.4) : 0;\n      if (s & 1) {       // we'll swap `U` and `A` an odd number of times\n        std::swap(A, U); // so let them switch places\n        A << U * exp2(-s);\n      } else if (s > 0) A *= exp2(-s);\n      A2 << A * A;\n      // here we take an estrin (instead of horner) approach to cut down flops\n      SquareMatrix<T> A4{A2 * A2}, A6{A2 * A4};\n      B << A6 * (A6 + 16380 * A4 + 40840800 * A2) +\n             (33522128640 * A6 + 10559470521600 * A4 + 1187353796428800 * A2) +\n             32382376266240000 * I;\n      U << A * B;\n      A << A6 * (182 * A6 + 960960 * A4 + 1323241920 * A2) +\n             (670442572800 * A6 + 129060195264000 * A4 +\n              7771770303897600 * A2) +\n             64764752532480000 * I;\n    }\n  }\n  containers::tie(A, U) << containers::Tuple(A + U, A - U);\n  LU::ldiv(U, MutPtrMatrix<T>(A));\n  for (; s--; std::swap(A, U)) U << A * A;\n}\n```")
└
ERROR: ArgumentError: Could not match codeblock:
```c++
template <typename T> constexpr void expm(MutSquarePtrMatrix<T> A) {
// more stuff
```
instead of the unhelpful:
```julia
Franklin Warning: in <index.md>
│ Encountered an issue processing 'index.md' in rk/writing/spmd_blog.
│ Verify, then re-start the Franklin server.
│ The error is displayed below:
│ ErrorException("type Nothing has no field captures")
└
ERROR: type Nothing has no field captures
Stacktrace:
  [1] getproperty(x::Nothing, f::Symbol)
    @ Base ./Base.jl:37
```

The former lets me know where in my markdown document the problem is, and gives me a clue to figure out that it's supposed to be "cpp" instead of "c++".