### PR TITLE
fix verify_links to accept doi links

### DIFF
--- a/src/manager/post_processing.jl
+++ b/src/manager/post_processing.jl
@@ -302,7 +302,8 @@ function verify_links_page(path::AS, online::Bool)
             link = m.captures[1] * m.captures[2]
             ok = false
             try
-                ok = HTTP.request("HEAD", link, timeout=3).status == 200
+                headers = contains(link, "doi.org") ? ["Accept" => "application/x-bibtex"] : []
+                ok = HTTP.request("HEAD", link, headers, timeout=3).status == 200
             catch e
             end
             if !ok


### PR DESCRIPTION
I'm not sure this is useful but many dois of mine get rejected and pop up during the link verification. Adding the x-bibtex header (which I spotted in https://github.com/JuliaWeb/HTTP.jl/issues/796) seems to fix that for me, hence this tiny PR. Do with it what you will!